### PR TITLE
Small bug fixes for persons email address screen

### DIFF
--- a/locales/cy/what-is-persons-email-address.json
+++ b/locales/cy/what-is-persons-email-address.json
@@ -1,6 +1,6 @@
 {
     "whatIs" : "What is welsh",
-    "emailAddress" : "'s email address welsh",
+    "emailAddress" : "'s email address? welsh",
     "theyMustAbleToAccess" : "They must be able to access emails sent to this address. welsh",
     "confirmEmail" : "Confirm their email address welsh",
 

--- a/locales/en/what-is-persons-email-address.json
+++ b/locales/en/what-is-persons-email-address.json
@@ -1,6 +1,6 @@
 {
     "whatIs" : "What is ",
-    "emailAddress" : "'s email address",
+    "emailAddress" : "'s email address?",
     "theyMustAbleToAccess" : "They must be able to access emails sent to this address.",
     "confirmEmail" : "Confirm their email address",
     

--- a/src/views/personal-code/personal-code.njk
+++ b/src/views/personal-code/personal-code.njk
@@ -5,7 +5,7 @@
 {% block main_content %}
     <form action="" method="POST">
         <h1 class="govuk-heading-l">
-            {{ firstName }} {{ lastName }} {{ i18n.codePageHeading }}
+            {{ firstName }} {{ lastName }}{{ i18n.codePageHeading }}
         </h1>
         <p class="govuk-body">
             {{ i18n.onceYou }} {{ firstName }} {{ lastName }}  {{ i18n.identity }}

--- a/src/views/persons-email/persons-email.njk
+++ b/src/views/persons-email/persons-email.njk
@@ -9,9 +9,8 @@
             <h1 class="govuk-heading-l">{{i18n.whatIs}} {{firstName}} {{lastName}}{{i18n.emailAddress}}</h1>
            
             {{ govukInput({
-                label: {
-                    text: i18n.theyMustAbleToAccess,
-                    classes: "govuk-hint"
+                hint: {
+                    text: i18n.theyMustAbleToAccess
                 },
                 errorMessage: {
                     text: errors["email-address"].text


### PR DESCRIPTION
Added question mark to the end of H1
Removed space between surname and the apostrophe
Changed text above email input to be hint text 