### PR TITLE
Capturing Matomo events by page title

### DIFF
--- a/src/controllers/addressListController.ts
+++ b/src/controllers/addressListController.ts
@@ -5,7 +5,7 @@ import { formatValidationError, getPageProperties } from "../validations/validat
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { HOME_ADDRESS_MANUAL, HOME_ADDRESS, BASE_URL, CHOOSE_AN_ADDRESS, CONFIRM_HOME_ADDRESS } from "../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { ADDRESS_LIST, USER_DATA } from "../utils/constants";
+import { ADDRESS_LIST, USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_LINK_CLICK } from "../utils/constants";
 import { ClientData } from "model/ClientData";
 import { Address } from "model/Address";
 import { saveDataInSession } from "../utils/sessionHelper";
@@ -26,6 +26,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         currentUrl,
         previousPage,
         addresses: addressList,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
+        matomoLinkClick: MATOMO_LINK_CLICK,
         manualAddressLink,
         firstname: clientData.firstName,
         lastname: clientData.lastName

--- a/src/controllers/checkYourAnswers.ts
+++ b/src/controllers/checkYourAnswers.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import * as config from "../config";
 import { BASE_URL, CHECK_YOUR_ANSWERS, CONFIRM_IDENTITY_VERIFICATION, CONFIRMATION } from "../types/pageURL";
-import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
+import { USER_DATA, REFERENCE, MATOMO_BUTTON_CLICK } from "../utils/constants";
 import { ClientData } from "../model/ClientData";
 import { Session } from "@companieshouse/node-session-handler";
 import { FormatService } from "../services/formatService";

--- a/src/controllers/checkYourAnswers.ts
+++ b/src/controllers/checkYourAnswers.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import * as config from "../config";
 import { BASE_URL, CHECK_YOUR_ANSWERS, CONFIRM_IDENTITY_VERIFICATION, CONFIRMATION } from "../types/pageURL";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
 import { ClientData } from "../model/ClientData";
 import { Session } from "@companieshouse/node-session-handler";
 import { FormatService } from "../services/formatService";
@@ -37,6 +37,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         ...getLocaleInfo(locales, lang),
         currentUrl,
         previousPage,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
         clientData: {
             ...clientData,
             address: formattedAddress,

--- a/src/controllers/confirmHomeAddressController.ts
+++ b/src/controllers/confirmHomeAddressController.ts
@@ -3,7 +3,7 @@ import * as config from "../config";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { HOME_ADDRESS, BASE_URL, CONFIRM_HOME_ADDRESS, WHEN_IDENTITY_CHECKS_COMPLETED, HOME_ADDRESS_MANUAL } from "../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_LINK_CLICK } from "../utils/constants";
 import { ClientData } from "model/ClientData";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -17,6 +17,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         editPage: addLangToUrl(BASE_URL + HOME_ADDRESS_MANUAL, lang),
         ...getLocaleInfo(locales, lang),
         currentUrl: BASE_URL + CONFIRM_HOME_ADDRESS,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
+        matomoLinkClick: MATOMO_LINK_CLICK,
         address: clientData?.address,
         firstName: clientData?.firstName,
         lastName: clientData?.lastName

--- a/src/controllers/confirmIdentityVerificationController.ts
+++ b/src/controllers/confirmIdentityVerificationController.ts
@@ -3,7 +3,7 @@ import * as config from "../config";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { BASE_URL, CONFIRM_IDENTITY_VERIFICATION, CHECK_YOUR_ANSWERS, WHICH_IDENTITY_DOCS_CHECKED_GROUP1, WHICH_IDENTITY_DOCS_CHECKED_GROUP2 } from "../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
 import { ClientData } from "../model/ClientData";
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../validations/validation";
@@ -20,6 +20,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         previousPage: addLangToUrl(getBackUrl(clientData.howIdentityDocsChecked!), lang),
         ...getLocaleInfo(locales, lang),
         currentUrl: BASE_URL + CONFIRM_IDENTITY_VERIFICATION,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
         firstName: clientData?.firstName,
         lastName: clientData?.lastName,
         formattedDate

--- a/src/controllers/dateOfBirthController.ts
+++ b/src/controllers/dateOfBirthController.ts
@@ -5,7 +5,7 @@ import { formatValidationError, getPageProperties } from "../validations/validat
 import { BASE_URL, DATE_OF_BIRTH, EMAIL_ADDRESS, HOME_ADDRESS } from "../types/pageURL";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
 import { ClientData } from "model/ClientData";
 import { saveDataInSession } from "../utils/sessionHelper";
 
@@ -31,6 +31,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         ...getLocaleInfo(locales, lang),
         previousPage,
         currentUrl,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
         firstName: clientData?.firstName,
         lastName: clientData?.lastName,
         payload

--- a/src/controllers/homeAddressController.ts
+++ b/src/controllers/homeAddressController.ts
@@ -7,7 +7,7 @@ import { ValidationError, validationResult } from "express-validator";
 import { Session } from "@companieshouse/node-session-handler";
 import { ClientData } from "model/ClientData";
 import { AddressLookUpService } from "../services/addressLookup";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_LINK_CLICK } from "../utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
@@ -25,6 +25,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         previousPage: addLangToUrl(BASE_URL + DATE_OF_BIRTH, lang),
         AddressManualLink: addLangToUrl(BASE_URL + HOME_ADDRESS_MANUAL, lang),
         currentUrl: BASE_URL + HOME_ADDRESS,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
+        matomoLinkClick: MATOMO_LINK_CLICK,
         payload,
         firstName: clientData.firstName,
         lastName: clientData.lastName

--- a/src/controllers/homeAddressManualController.ts
+++ b/src/controllers/homeAddressManualController.ts
@@ -4,7 +4,7 @@ import { NextFunction, Request, Response } from "express";
 import { BASE_URL, CONFIRM_HOME_ADDRESS, HOME_ADDRESS, HOME_ADDRESS_MANUAL } from "../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 import { ClientData } from "../model/ClientData";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../validations/validation";
 import { AddressManualService } from "../services/addressManualService";
@@ -24,6 +24,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         ...getLocaleInfo(locales, lang),
         previousPage,
         currentUrl,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
         firstName: clientData?.firstName,
         lastName: clientData?.lastName,
         payload

--- a/src/controllers/howIdentityDocumentsCheckedController.ts
+++ b/src/controllers/howIdentityDocumentsCheckedController.ts
@@ -6,7 +6,7 @@ import { formatValidationError, getPageProperties } from "../validations/validat
 import { validationResult } from "express-validator";
 import { Session } from "@companieshouse/node-session-handler";
 import { ClientData } from "model/ClientData";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT } from "../utils/constants";
 import { saveDataInSession } from "../utils/sessionHelper";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -20,6 +20,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         previousPage: addLangToUrl(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED, lang),
         currentUrl: BASE_URL + HOW_IDENTITY_DOCUMENTS_CHECKED,
         selectedOption: clientData?.howIdentityDocsChecked,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
+        matomoRadioSelection: MATOMO_RADIO_OPTION_SELECT,
         firstName: clientData?.firstName,
         lastName: clientData?.lastName
     });

--- a/src/controllers/identityDocumentsCheckedGroup1Controller.ts
+++ b/src/controllers/identityDocumentsCheckedGroup1Controller.ts
@@ -4,7 +4,7 @@ import { NextFunction, Request, Response } from "express";
 import { BASE_URL, WHICH_IDENTITY_DOCS_CHECKED_GROUP1, HOW_IDENTITY_DOCUMENTS_CHECKED, CONFIRM_IDENTITY_VERIFICATION } from "../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 import { ClientData } from "../model/ClientData";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT } from "../utils/constants";
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../validations/validation";
 import { CheckedDocumentsService } from "../services/checkedDocumentsService";
@@ -23,6 +23,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         ...getLocaleInfo(locales, lang),
         previousPage,
         currentUrl,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
+        matomoRadioSelection: MATOMO_RADIO_OPTION_SELECT,
         firstName: clientData?.firstName,
         lastName: clientData?.lastName,
         payload

--- a/src/controllers/identityDocumentsCheckedGroup2Controller.ts
+++ b/src/controllers/identityDocumentsCheckedGroup2Controller.ts
@@ -5,7 +5,7 @@ import { NextFunction, Request, Response } from "express";
 import { BASE_URL, WHICH_IDENTITY_DOCS_CHECKED_GROUP2, HOW_IDENTITY_DOCUMENTS_CHECKED, CONFIRM_IDENTITY_VERIFICATION, WHICH_IDENTITY_DOCS_CHECKED_GROUP1 } from "../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 import { ClientData } from "../model/ClientData";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT } from "../utils/constants";
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../validations/validation";
 import { CheckedDocumentsService } from "../services/checkedDocumentsService";
@@ -27,6 +27,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         ...getLocaleInfo(locales, lang),
         previousPage,
         currentUrl,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
+        matomoRadioSelection: MATOMO_RADIO_OPTION_SELECT,
         firstName: clientData?.firstName,
         lastName: clientData?.lastName,
         payload

--- a/src/controllers/indexController.ts
+++ b/src/controllers/indexController.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
 import { BASE_URL, PERSONS_NAME } from "../types/pageURL";
+import { MATOMO_LINK_CLICK, MATOMO_BUTTON_CLICK } from "../utils/constants";
 import {
     addLangToUrl,
     getLocaleInfo,
@@ -14,6 +15,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
     res.render(config.HOME, {
         ...getLocaleInfo(locales, lang),
+        matomoLinkClick: MATOMO_LINK_CLICK,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
         currentUrl: BASE_URL
     });
 };

--- a/src/controllers/personalCodeController.ts
+++ b/src/controllers/personalCodeController.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
 import { BASE_URL, PERSONS_NAME, PERSONAL_CODE, EMAIL_ADDRESS } from "../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { ClientData } from "../model/ClientData";
 
@@ -15,6 +15,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     res.render(config.PERSONAL_CODE, {
         previousPage: addLangToUrl(BASE_URL + PERSONS_NAME, lang),
         ...getLocaleInfo(locales, lang),
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
         currentUrl: BASE_URL + PERSONAL_CODE,
         firstName: clientData?.firstName,
         lastName: clientData?.lastName

--- a/src/controllers/personsEmailController.ts
+++ b/src/controllers/personsEmailController.ts
@@ -6,7 +6,7 @@ import { formatValidationError, getPageProperties } from "../validations/validat
 import { ValidationError, validationResult } from "express-validator";
 import { Session } from "@companieshouse/node-session-handler";
 import { ClientData } from "model/ClientData";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
 import { saveDataInSession } from "../utils/sessionHelper";
 import { findIdentityByEmail } from "../services/identityVerificationService";
 import logger from "../lib/Logger";
@@ -26,6 +26,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
     res.render(config.PERSONS_EMAIL, {
         ...getLocaleInfo(locales, lang),
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
         previousPage: addLangToUrl(BASE_URL + PERSONAL_CODE, lang),
         currentUrl: BASE_URL + EMAIL_ADDRESS,
         payload,

--- a/src/controllers/personsNameController.ts
+++ b/src/controllers/personsNameController.ts
@@ -4,7 +4,7 @@ import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../validations/validation";
 import { BASE_URL, PERSONS_NAME, PERSONAL_CODE } from "../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { saveDataInSession } from "../utils/sessionHelper";
 import { ClientData } from "../model/ClientData";
@@ -22,6 +22,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     res.render(config.PERSONS_NAME, {
         previousPage: addLangToUrl(BASE_URL, lang),
         ...getLocaleInfo(locales, lang),
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
         currentUrl: BASE_URL + PERSONS_NAME,
         payload
     });

--- a/src/controllers/signOutController.ts
+++ b/src/controllers/signOutController.ts
@@ -4,7 +4,7 @@ import { validationResult } from "express-validator";
 import { getPreviousPageUrl } from "../services/url";
 import { Session } from "@companieshouse/node-session-handler";
 import { formatValidationError, getPageProperties } from "../validations/validation";
-import { PREVIOUS_PAGE_URL } from "../utils/constants";
+import { PREVIOUS_PAGE_URL, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT } from "../utils/constants";
 import { selectLang, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { BASE_URL, SIGN_OUT_URL, ACCOUNTS_SIGNOUT_PATH } from "../types/pageURL";
 import { saveDataInSession } from "../utils/sessionHelper";
@@ -18,6 +18,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     res.render(config.SIGN_OUT_PAGE, {
         previousPage: (previousPageUrl),
         ...getLocaleInfo(locales, lang),
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
+        matomoRadioSelect: MATOMO_RADIO_OPTION_SELECT,
         currentUrl: BASE_URL + SIGN_OUT_URL
     });
 };

--- a/src/controllers/whenIdentityChecksCompletedController.ts
+++ b/src/controllers/whenIdentityChecksCompletedController.ts
@@ -28,7 +28,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         ...getLocaleInfo(locales, lang),
         previousPage: addLangToUrl(BASE_URL + CONFIRM_HOME_ADDRESS, lang),
         currentUrl: BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED,
-        matomoButtonCLick: MATOMO_BUTTON_CLICK,
+        matomoButtonClick: MATOMO_BUTTON_CLICK,
         firstName: clientData?.firstName,
         lastName: clientData?.lastName,
         payload

--- a/src/controllers/whenIdentityChecksCompletedController.ts
+++ b/src/controllers/whenIdentityChecksCompletedController.ts
@@ -5,7 +5,7 @@ import { formatValidationError, getPageProperties } from "../validations/validat
 import { BASE_URL, CONFIRM_HOME_ADDRESS, WHEN_IDENTITY_CHECKS_COMPLETED, HOW_IDENTITY_DOCUMENTS_CHECKED } from "../types/pageURL";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
-import { USER_DATA } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
 import { ClientData } from "model/ClientData";
 import { saveDataInSession } from "../utils/sessionHelper";
 
@@ -28,6 +28,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         ...getLocaleInfo(locales, lang),
         previousPage: addLangToUrl(BASE_URL + CONFIRM_HOME_ADDRESS, lang),
         currentUrl: BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED,
+        matomoButtonCLick: MATOMO_BUTTON_CLICK,
         firstName: clientData?.firstName,
         lastName: clientData?.lastName,
         payload

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,7 @@
 export const USER_DATA = "user";
 export const ADDRESS_LIST = "addressList";
 export const PREVIOUS_PAGE_URL: string = "previouspageurl";
+export const REFERENCE = "reference";
 
 // Matomo
 export const MATOMO_BUTTON_CLICK = "Click button";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,8 @@
 export const USER_DATA = "user";
 export const ADDRESS_LIST = "addressList";
 export const PREVIOUS_PAGE_URL: string = "previouspageurl";
+
+// Matomo
+export const MATOMO_BUTTON_CLICK = "Click button";
+export const MATOMO_LINK_CLICK = "Click link";
+export const MATOMO_RADIO_OPTION_SELECT = "Select option";

--- a/src/views/check-your-answers/check-your-answers.njk
+++ b/src/views/check-your-answers/check-your-answers.njk
@@ -186,8 +186,20 @@
         }
         ]
     }) }}
+
     {{ govukButton({
-            text: i18n.continueSend
-           }) }}
+        text: i18n.continueSend,
+        id: "continue-send-button",
+        attributes: {
+          "data-event-id": "Continue and Send"
+        }
+    }) }}
+
   </form>
+  
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+    trackEventBasedOnPageTitle("continue-send-button", "{{title}}", "{{matomoButtonClick}}", "Continue and Send");
+</script>
+
 {% endblock main_content %}

--- a/src/views/check-your-answers/check-your-answers.njk
+++ b/src/views/check-your-answers/check-your-answers.njk
@@ -189,10 +189,7 @@
 
     {{ govukButton({
         text: i18n.continueSend,
-        id: "continue-send-button",
-        attributes: {
-          "data-event-id": "Continue and Send"
-        }
+        id: "continue-send-button"
     }) }}
 
   </form>

--- a/src/views/confirm-home-address/confirm-home-address.njk
+++ b/src/views/confirm-home-address/confirm-home-address.njk
@@ -16,14 +16,11 @@
       <li>{{ address.postcode }}</li>
     </ul>
     <p class="govuk-body">
-      <a href={{editPage}} class="govuk-link govuk-link--no-visited-state" id="edit-address-link" data-event-id="Edit address">{{ i18n.EditAddress }}</a>
+      <a href={{editPage}} class="govuk-link govuk-link--no-visited-state" id="edit-address-link">{{ i18n.EditAddress }}</a>
     </p>
     {{ govukButton({
       text: i18n.ConfirmAndContinue,
-      id: "confirm-and-continue-button",
-      attributes: {
-        "data-event-id": "Continue-confirm address"
-      }
+      id: "confirm-and-continue-button"
     }) }}
   </form>
 

--- a/src/views/confirm-home-address/confirm-home-address.njk
+++ b/src/views/confirm-home-address/confirm-home-address.njk
@@ -16,13 +16,21 @@
       <li>{{ address.postcode }}</li>
     </ul>
     <p class="govuk-body">
-      <a href={{editPage}} class="govuk-link govuk-link--no-visited-state"  data-event-id="Edit address">{{ i18n.EditAddress }}</a>
+      <a href={{editPage}} class="govuk-link govuk-link--no-visited-state" id="edit-address-link" data-event-id="Edit address">{{ i18n.EditAddress }}</a>
     </p>
     {{ govukButton({
       text: i18n.ConfirmAndContinue,
+      id: "confirm-and-continue-button",
       attributes: {
-        "data-event-id": "CONFIRM AND CONTINUE"
+        "data-event-id": "Continue-confirm address"
       }
     }) }}
   </form>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+  trackEventBasedOnPageTitle("confirm-and-continue-button", "{{title}}", "{{matomoButtonClick}}", "Continue-confirm address");
+  trackEventBasedOnPageTitle("edit-address-link", "{{title}}", "{{matomoLinkClick}}", "Edit address");
+</script>
+
 {% endblock main_content %}

--- a/src/views/confirm-identity-verification/confirm-identity-verification.njk
+++ b/src/views/confirm-identity-verification/confirm-identity-verification.njk
@@ -35,10 +35,7 @@
 
     {{ govukButton({
         text: i18n.Continue,
-        id: "continue-button",
-        attributes: {
-        "data-event-id": "Continue"
-        }
+        id: "continue-button"
     }) }}
 </form>
 

--- a/src/views/confirm-identity-verification/confirm-identity-verification.njk
+++ b/src/views/confirm-identity-verification/confirm-identity-verification.njk
@@ -35,10 +35,16 @@
 
     {{ govukButton({
         text: i18n.Continue,
+        id: "continue-button",
         attributes: {
-        "data-event-id": "CONTINUE"
+        "data-event-id": "Continue"
         }
     }) }}
 </form>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+    trackEventBasedOnPageTitle("continue-button", "{{title}}", "{{matomoButtonClick}}", "Continue");
+</script>
 
 {% endblock main_content %}

--- a/src/views/home-address-list/home-address-list.njk
+++ b/src/views/home-address-list/home-address-list.njk
@@ -44,14 +44,22 @@
         </div>
         {{ govukButton({
             text: i18n.ConfirmAndContinue,
+            id: "confirm-and-continue-button",
             attributes: {
-              "data-event-id": "CONTINUE - SELECT ADDRESS"
+              "data-event-id": "Confirm and Continue"
             }
           }) }}
     </form>
     
     {# Manual address entry link #}
     <p>
-        <a href= {{ manualAddressLink }} class="govuk-link" data-event-id="Enter address manually">{{ i18n.homeAddressManualLink }}</a>
+        <a href= {{ manualAddressLink }} class="govuk-link" id="enter-address-manually-link" data-event-id="Enter address manually">{{ i18n.homeAddressManualLink }}</a>
     </p>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+    trackEventBasedOnPageTitle("confirm-and-continue-button", "{{title}}", "{{matomoButtonClick}}", "Confirm and Continue");
+    trackEventBasedOnPageTitle("enter-address-manually-link", "{{title}}", "{{matomoLinkClick}}", "Enter address manually");
+</script>
+
 {% endblock main_content %}

--- a/src/views/home-address-list/home-address-list.njk
+++ b/src/views/home-address-list/home-address-list.njk
@@ -44,16 +44,13 @@
         </div>
         {{ govukButton({
             text: i18n.ConfirmAndContinue,
-            id: "confirm-and-continue-button",
-            attributes: {
-              "data-event-id": "Confirm and Continue"
-            }
+            id: "confirm-and-continue-button"
           }) }}
     </form>
     
     {# Manual address entry link #}
     <p>
-        <a href= {{ manualAddressLink }} class="govuk-link" id="enter-address-manually-link" data-event-id="Enter address manually">{{ i18n.homeAddressManualLink }}</a>
+        <a href= {{ manualAddressLink }} class="govuk-link" id="enter-address-manually-link">{{ i18n.homeAddressManualLink }}</a>
     </p>
 
 <!-- Calling Matomo event script to capture event actions based on page title -->

--- a/src/views/home-address-manual/home-address-manual.njk
+++ b/src/views/home-address-manual/home-address-manual.njk
@@ -97,10 +97,7 @@
         }) }}
        {{ govukButton({
             text: i18n.Continue,
-            id: "continue-button",
-            attributes: {
-              "data-event-id": "Continue"
-            }
+            id: "continue-button"
         }) }}
   </form>
   

--- a/src/views/home-address-manual/home-address-manual.njk
+++ b/src/views/home-address-manual/home-address-manual.njk
@@ -97,9 +97,16 @@
         }) }}
        {{ govukButton({
             text: i18n.Continue,
+            id: "continue-button",
             attributes: {
-              "data-event-id": "CONTINUE - MANUAL ADDRESS"
+              "data-event-id": "Continue"
             }
         }) }}
   </form>
+  
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+    trackEventBasedOnPageTitle("continue-button", "{{title}}", "{{matomoButtonClick}}", "Continue");
+</script>
+
 {% endblock main_content %}

--- a/src/views/home-address/home-address.njk
+++ b/src/views/home-address/home-address.njk
@@ -41,13 +41,10 @@
     }) }}
     {{ govukButton({
       text: i18n.homeAddressFindAddressBtn,
-      id: "find-address-button",
-      attributes: {
-        "data-event-id": "Find address"
-      }
+      id: "find-address-button"
     }) }}
     <p>
-      <a href={{AddressManualLink}} class="govuk-link" id="enter-address-manually-link" data-event-id="Enter address manually">{{ i18n.homeAddressManualLink }}</a>
+      <a href={{AddressManualLink}} class="govuk-link" id="enter-address-manually-link">{{ i18n.homeAddressManualLink }}</a>
     </p>
   </form>
 

--- a/src/views/home-address/home-address.njk
+++ b/src/views/home-address/home-address.njk
@@ -41,12 +41,20 @@
     }) }}
     {{ govukButton({
       text: i18n.homeAddressFindAddressBtn,
+      id: "find-address-button",
       attributes: {
-        "data-event-id": "FIND ADDRESS"
+        "data-event-id": "Find address"
       }
     }) }}
     <p>
-      <a href={{AddressManualLink}} class="govuk-link" data-event-id="Enter address manually">{{ i18n.homeAddressManualLink }}</a>
+      <a href={{AddressManualLink}} class="govuk-link" id="enter-address-manually-link" data-event-id="Enter address manually">{{ i18n.homeAddressManualLink }}</a>
     </p>
   </form>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+  trackEventBasedOnPageTitle("find-address-button", "{{title}}" + " - Tell Companies House you have verified someone’s identity", "{{matomoButtonClick}}", "Find address");
+  trackEventBasedOnPageTitle("enter-address-manually-link", "{{title}}" + " - Tell Companies House you have verified someone’s identity", "{{matomoLinkClick}}", "Enter address manually");
+</script>
+
 {% endblock %}

--- a/src/views/how-identity-documents-checked/how-identity-documents-checked.njk
+++ b/src/views/how-identity-documents-checked/how-identity-documents-checked.njk
@@ -32,9 +32,6 @@
                     id: "option-1",
                     hint: {
                         text: i18n.howIdentityDocsCheckedOption1hint
-                    },
-                    attributes: {
-                        "data-event-id": "Option 1"
                     }
                 },
                 {
@@ -43,9 +40,6 @@
                     id: "option-2",
                     hint: {
                         text: i18n.howIdentityDocsCheckedOption2hint
-                    },    
-                    attributes: {
-                        "data-event-id": "Option 2"
                     }
                 }
             ]
@@ -65,10 +59,7 @@
         </details>
         {{ govukButton({
             text: i18n.Continue,
-            id: "continue-button",
-            attributes: {
-            "data-event-id": "Continue"
-            }
+            id: "continue-button"
         }) }}
     </div>
   </form>

--- a/src/views/how-identity-documents-checked/how-identity-documents-checked.njk
+++ b/src/views/how-identity-documents-checked/how-identity-documents-checked.njk
@@ -29,21 +29,23 @@
                 {
                     value: "OPTION1",
                     text: i18n.howIdentityDocsCheckedOption1,
+                    id: "option-1",
                     hint: {
                         text: i18n.howIdentityDocsCheckedOption1hint
                     },
                     attributes: {
-                        "data-event-id": "option1"
+                        "data-event-id": "Option 1"
                     }
                 },
                 {
                     value: "OPTION2",
                     text: i18n.howIdentityDocsCheckedOption2,
+                    id: "option-2",
                     hint: {
                         text: i18n.howIdentityDocsCheckedOption2hint
                     },    
                     attributes: {
-                        "data-event-id": "option2"
+                        "data-event-id": "Option 2"
                     }
                 }
             ]
@@ -63,10 +65,19 @@
         </details>
         {{ govukButton({
             text: i18n.Continue,
+            id: "continue-button",
             attributes: {
-            "data-event-id": "CONTINUE - how were idenity documents checked"
+            "data-event-id": "Continue"
             }
         }) }}
     </div>
   </form>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+    trackEventBasedOnPageTitle("option-1", "{{title}}", "{{matomoRadioSelection}}", "Option 1");
+    trackEventBasedOnPageTitle("option-2", "{{title}}", "{{matomoRadioSelection}}", "Option 2");
+    trackEventBasedOnPageTitle("continue-button", "{{title}}", "{{matomoButtonClick}}", "Continue");
+</script>
+
 {% endblock main_content %}

--- a/src/views/identity-checks-completed/identity-checks-completed.njk
+++ b/src/views/identity-checks-completed/identity-checks-completed.njk
@@ -88,11 +88,17 @@
 
        {{ govukButton({
          text: i18n.Continue,
+         id: "continue-button",
          attributes: {
-          "onClick": "_paq.push(['trackGoal', '16']);"
+          "data-event-id": "Continue"
          }
        }) }}
      </form>
    </div>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+  trackEventBasedOnPageTitle("continue-button", "{{title}}", "{{matomoButtonClick}}", "Continue");
+</script>
 
  {% endblock main_content %}

--- a/src/views/identity-checks-completed/identity-checks-completed.njk
+++ b/src/views/identity-checks-completed/identity-checks-completed.njk
@@ -88,10 +88,7 @@
 
        {{ govukButton({
          text: i18n.Continue,
-         id: "continue-button",
-         attributes: {
-          "data-event-id": "Continue"
-         }
+         id: "continue-button"
        }) }}
      </form>
    </div>

--- a/src/views/identity-documents-group-1/identity-documents-group-1.njk
+++ b/src/views/identity-documents-group-1/identity-documents-group-1.njk
@@ -23,67 +23,43 @@
             {
                 value: "biometricPassport",
                 text: i18n.biometricPassport,
-                id: "biometric-passport",
-                attributes: {
-                    "data-event-id": "Biometric or machine readable passport"
-                }
+                id: "biometric-passport"
             },
             {
                 value: "irishPassport",
                 text: i18n.irishPassport,
-                id: "irish-passport",
-                attributes: {
-                    "data-event-id": "Irish Passport Card"
-                }
+                id: "irish-passport"
             },
             {
                 value: "ukDriversLicence",
                 text: i18n.ukDriversLicence,
-                id: "uk-drivers-licence",
-                attributes: {
-                    "data-event-id": "UK, Channel Islands,  Isle of Man, and EU photocard driving license (full or provisional)"
-                }
+                id: "uk-drivers-licence"
             },
             {
                 value: "identityCard",
                 text: i18n.identityCard,
-                id: "identity-card",
-                attributes: {
-                    "data-event-id": "Identity card with biometric information from the EU, Norway, Iceland or Liechtenstein"
-                }
+                id: "identity-card"
             },
             {
                 value: "biometricPermit",
                 text: i18n.biometricPermit,
-                id: "uk-biometric-residence-permit",
-                attributes: {
-                    "data-event-id": "UK biometric residence permit (BRP)"
-                }
+                id: "uk-biometric-residence-permit"
             },
             {
                 value: "biometricCard",
                 text: i18n.biometricCard,
-                id: "uk-biometric-residence-card",
-                attributes: {
-                    "data-event-id": "UK biometric residence card (BRC)"
-                }
+                id: "uk-biometric-residence-card"
             },
             {
                 value: "frontierPermit",
                 text: i18n.frontierPermit,
-                id: "uk-frontier-worker-permit",
-                attributes: {
-                    "data-event-id": "UK Frontier worker permit"
-                }
+                id: "uk-frontier-worker-permit"
             }
             ]
         }) }}
         {{ govukButton({
             text: i18n.Continue,
-            id: "continue-button",
-            attributes: {
-                "data-event-id": "Continue-DC1"
-            }
+            id: "continue-button"
         }) }}
     </form>
 

--- a/src/views/identity-documents-group-1/identity-documents-group-1.njk
+++ b/src/views/identity-documents-group-1/identity-documents-group-1.njk
@@ -23,60 +23,80 @@
             {
                 value: "biometricPassport",
                 text: i18n.biometricPassport,
+                id: "biometric-passport",
                 attributes: {
-                    "data-event-id": "biometricPassport"
+                    "data-event-id": "Biometric or machine readable passport"
                 }
             },
             {
                 value: "irishPassport",
                 text: i18n.irishPassport,
+                id: "irish-passport",
                 attributes: {
-                    "data-event-id": "irishPassport"
+                    "data-event-id": "Irish Passport Card"
                 }
             },
             {
                 value: "ukDriversLicence",
                 text: i18n.ukDriversLicence,
+                id: "uk-drivers-licence",
                 attributes: {
-                    "data-event-id": "ukDriversLicence"
+                    "data-event-id": "UK, Channel Islands,  Isle of Man, and EU photocard driving license (full or provisional)"
                 }
             },
             {
                 value: "identityCard",
                 text: i18n.identityCard,
+                id: "identity-card",
                 attributes: {
-                    "data-event-id": "identityCard"
+                    "data-event-id": "Identity card with biometric information from the EU, Norway, Iceland or Liechtenstein"
                 }
             },
             {
                 value: "biometricPermit",
                 text: i18n.biometricPermit,
+                id: "uk-biometric-residence-permit",
                 attributes: {
-                    "data-event-id": "biometricPermit"
+                    "data-event-id": "UK biometric residence permit (BRP)"
                 }
             },
             {
                 value: "biometricCard",
                 text: i18n.biometricCard,
+                id: "uk-biometric-residence-card",
                 attributes: {
-                    "data-event-id": "biometricCard"
+                    "data-event-id": "UK biometric residence card (BRC)"
                 }
             },
             {
                 value: "frontierPermit",
                 text: i18n.frontierPermit,
+                id: "uk-frontier-worker-permit",
                 attributes: {
-                    "data-event-id": "frontierPermit"
+                    "data-event-id": "UK Frontier worker permit"
                 }
             }
             ]
         }) }}
         {{ govukButton({
             text: i18n.Continue,
+            id: "continue-button",
             attributes: {
-                "data-event-id": "CONTINUE - dc1"
+                "data-event-id": "Continue-DC1"
             }
         }) }}
     </form>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+    trackEventBasedOnPageTitle("biometric-passport", "{{title}}", "{{matomoRadioSelection}}", "Biometric or machine readable passport");
+    trackEventBasedOnPageTitle("irish-passport", "{{title}}", "{{matomoRadioSelection}}", "Irish Passport Card");
+    trackEventBasedOnPageTitle("uk-drivers-licence", "{{title}}", "{{matomoRadioSelection}}", "UK, Channel Islands,  Isle of Man, and EU photocard driving license (full or provisional)");
+    trackEventBasedOnPageTitle("identity-card", "{{title}}", "{{matomoRadioSelection}}", "Identity card with biometric information from the EU, Norway, Iceland or Liechtenstein");
+    trackEventBasedOnPageTitle("uk-biometric-residence-permit", "{{title}}", "{{matomoRadioSelection}}", "UK biometric residence permit (BRP)");
+    trackEventBasedOnPageTitle("uk-biometric-residence-card", "{{title}}", "{{matomoRadioSelection}}", "UK biometric residence card (BRC)");
+    trackEventBasedOnPageTitle("uk-frontier-worker-permit", "{{title}}", "{{matomoRadioSelection}}", "UK Frontier worker permit");
+    trackEventBasedOnPageTitle("continue-button", "{{title}}", "{{matomoButtonClick}}", "Continue-DC1");
+</script>
     
 {% endblock main_content %}

--- a/src/views/identity-documents-group-2/identity-documents-group-2.njk
+++ b/src/views/identity-documents-group-2/identity-documents-group-2.njk
@@ -22,114 +22,72 @@ i18n.identityDocumentsIDVTitle %}
             {
                 value: "passportIrishCard",
                 text: i18n.passportIrishCard,
-                id: "passport-or-irish-passport-card",
-                attributes: {
-                    "data-event-id": "Passport or Irish passport card"
-                }
+                id: "passport-or-irish-passport-card"
             },
             {
                 value: "identityCard",
                 text: i18n.identityCard,
-                id: "identity-card",
-                attributes: {
-                    "data-event-id": "Identity card with biometric information from the EU, Norway, Iceland or Liechtenstein"
-                }
+                id: "identity-card"
             },
             {
                 value: "ukBRP",
                 text: i18n.ukBRP,
-                id: "uk-biometric-residence-permit",
-                attributes: {
-                    "data-event-id": "UK biometric residence permit (BRP)"
-                }
+                id: "uk-biometric-residence-permit"
             },
             {
                 value: "ukBRC",
                 text: i18n.ukBRC,
-                id: "uk-biometric-residence-card",
-                attributes: {
-                    "data-event-id": "UK biometric residence card (BRC)"
-                }
+                id: "uk-biometric-residence-card"
             },
             {
                 value: "passCard",
                 text: i18n.passCard,
-                id: "uk-accredited-pass-card",
-                attributes: {
-                    "data-event-id": "UK accredited PASS card"
-                }
+                id: "uk-accredited-pass-card"
             },
             {
                 value: "ukEuDigitalCard",
                 text: i18n.ukEuDigitalCard,
-                id: "uk-eu-driver-digital-tacograph-card",
-                attributes: {
-                    "data-event-id": "UK or EU driver digital tachograph card"
-                }
+                id: "uk-eu-driver-digital-tacograph-card"
             },
             {
                 value: "fullDrivingLicense",
                 text: i18n.fullDrivingLicense,
-                id: "uk-drivers-licence",
-                attributes: {
-                    "data-event-id": "UK, Channel Islands,  Isle of Man, and EU photocard driving license (full or provisional)"
-                }
+                id: "uk-drivers-licence"
             },
             {
                 value: "ukForceCard",
                 text: i18n.ukForceCard,
-                id: "uk-forces-id-card",
-                attributes: {
-                    "data-event-id": "UK HM Forces ID card"
-                }
+                id: "uk-forces-id-card"
             },
             {
                 value: "ukArmedForceCard",
                 text: i18n.ukArmedForceCard,
-                id: "uk-armed-forces-veteran-card",
-                attributes: {
-                    "data-event-id": "UK HM Armed Forces Veteran Card"
-                }
+                id: "uk-armed-forces-veteran-card"
             },
             {
                 value: "ukFrontierPermit",
                 text: i18n.ukFrontierPermit,
-                id: "uk-frontier-worker-permit",
-                attributes: {
-                    "data-event-id": "UK Frontier worker permit"
-                }
+                id: "uk-frontier-worker-permit"
             },
             {
                 value: "photoWorkPermit",
                 text: i18n.photoWorkPermit,
-                id: "photo-work-permit",
-                attributes: {
-                    "data-event-id": "Photographic work permit (government issued)"
-                }
+                id: "photo-work-permit"
             },
             {
                 value: "photoimmigrationDoc",
                 text: i18n.photoimmigrationDoc,
-                id: "photo-immigration-doc",
-                attributes: {
-                    "data-event-id": "Photographic immigration document"
-                }
+                id: "photo-immigration-doc"
             },
             {
                 value: "photoVisa",
                 text: i18n.photoVisa,
-                id: "photo-visa",
-                attributes: {
-                    "data-event-id": "Photographic visa"
-                }
+                id: "photo-visa"
             },
             {
                 value: "ukFirearmsLicence",
                 text: i18n.ukFirearmsLicence,
-                id: "uk-firearms-licence",
-                attributes: {
-                    "data-event-id": "UK, Channel Islands and Isle of Man Firearms Licence"
-                }
+                id: "uk-firearms-licence"
             },
             {
                 value: "photoIdPrado",
@@ -137,9 +95,6 @@ i18n.identityDocumentsIDVTitle %}
                 id: "photo-id-prado",
                 hint: {
                         text: i18n.photoIdPradoHint
-                        },
-                attributes: {
-                    "data-event-id": "Photographic ID listed on PRADO"
                 }
             }
             ]
@@ -160,91 +115,58 @@ i18n.identityDocumentsIDVTitle %}
             {
                 value: "birthCert",
                 text: i18n.birthCert,
-                id: "birth-cert",
-                attributes: {
-                    "data-event-id": "Birth or adoption certificate"
-                }
+                id: "birth-cert"
             },
             {
                 value: "marriageCert",
                 text: i18n.marriageCert,
-                id: "marriage-cert",
-                attributes: {
-                    "data-event-id": "Marriage or civil partnership certificate"
-                }
+                id: "marriage-cert"
             },
             {
                 value: "noPhotoimmigrationDoc",
                 text: i18n.noPhotoimmigrationDoc,
-                id: "non-photo-immigration-doc",
-                attributes: {
-                    "data-event-id": "Non-photographic immigration document"
-                }
+                id: "non-photo-immigration-doc"
             },
             {
                 value: "noPhotoVisa",
                 text: i18n.noPhotoVisa,
-                id: "non-photo-visa",
-                attributes: {
-                    "data-event-id": "Non-photographic visa"
-                }
+                id: "non-photo-visa"
             },
             {
                 value: "noPhotoWorkPermit",
                 text: i18n.noPhotoWorkPermit,
-                id: "non-photo-work-permit",
-                attributes: {
-                    "data-event-id": "Non-photographic work permit"
-                }
+                id: "non-photo-work-permit"
             },
             {
                 value: "bankStatement",
                 text: i18n.bankStatement,
-                id: "bank-statement",
-                attributes: {
-                    "data-event-id": "Bank or building society statement"
-                }
+                id: "bank-statement"
             },
             {
                 value: "rentalAgreement",
                 text: i18n.rentalAgreement,
-                id: "rental-agreement",
-                attributes: {
-                    "data-event-id": "UK local authority or social housing rental agreement (for the person's current address)"
-                }
+                id: "rental-agreement"
             },
             {
                 value: "morgageStatement",
                 text: i18n.morgageStatement,
-                id: "mortgage-statement",
-                attributes: {
-                    "data-event-id": "Mortgage statement (for the person's current address)"
-                }
+                id: "mortgage-statement"
             },
             {
                 value: "taxStatement",
                 text: i18n.taxStatement,
-                id: "council-tax-statement",
-                attributes: {
-                    "data-event-id": "UK Council Tax statement (for the person's current address)"
-                }
+                id: "council-tax-statement"
             },
             {
                 value: "utilityBill",
                 text: i18n.utilityBill,
-                id: "utility-bill",
-                attributes: {
-                    "data-event-id": "Utility bill (for the person's current address)"
-                }
+                id: "utility-bill"
             }
             ]
         }) }}
         {{ govukButton({
             text: i18n.Continue,
-            id: "continue-button",
-            attributes: {
-                "data-event-id": "Continue-DC2"
-            }
+            id: "continue-button"
         }) }}
     </form>
 

--- a/src/views/identity-documents-group-2/identity-documents-group-2.njk
+++ b/src/views/identity-documents-group-2/identity-documents-group-2.njk
@@ -22,109 +22,124 @@ i18n.identityDocumentsIDVTitle %}
             {
                 value: "passportIrishCard",
                 text: i18n.passportIrishCard,
+                id: "passport-or-irish-passport-card",
                 attributes: {
-                    "data-event-id": "passportIrishCard"
+                    "data-event-id": "Passport or Irish passport card"
                 }
             },
             {
                 value: "identityCard",
                 text: i18n.identityCard,
+                id: "identity-card",
                 attributes: {
-                    "data-event-id": "identityCard"
+                    "data-event-id": "Identity card with biometric information from the EU, Norway, Iceland or Liechtenstein"
                 }
             },
             {
                 value: "ukBRP",
                 text: i18n.ukBRP,
+                id: "uk-biometric-residence-permit",
                 attributes: {
-                    "data-event-id": "ukBRP"
+                    "data-event-id": "UK biometric residence permit (BRP)"
                 }
             },
             {
                 value: "ukBRC",
                 text: i18n.ukBRC,
+                id: "uk-biometric-residence-card",
                 attributes: {
-                    "data-event-id": "ukBRC"
+                    "data-event-id": "UK biometric residence card (BRC)"
                 }
             },
             {
                 value: "passCard",
                 text: i18n.passCard,
+                id: "uk-accredited-pass-card",
                 attributes: {
-                    "data-event-id": "passCard"
+                    "data-event-id": "UK accredited PASS card"
                 }
             },
             {
                 value: "ukEuDigitalCard",
                 text: i18n.ukEuDigitalCard,
+                id: "uk-eu-driver-digital-tacograph-card",
                 attributes: {
-                    "data-event-id": "ukEuDigitalCard"
+                    "data-event-id": "UK or EU driver digital tachograph card"
                 }
             },
             {
                 value: "fullDrivingLicense",
                 text: i18n.fullDrivingLicense,
+                id: "uk-drivers-licence",
                 attributes: {
-                    "data-event-id": "fullDrivingLicense"
+                    "data-event-id": "UK, Channel Islands,  Isle of Man, and EU photocard driving license (full or provisional)"
                 }
             },
             {
                 value: "ukForceCard",
                 text: i18n.ukForceCard,
+                id: "uk-forces-id-card",
                 attributes: {
-                    "data-event-id": "ukForceCard"
+                    "data-event-id": "UK HM Forces ID card"
                 }
             },
             {
                 value: "ukArmedForceCard",
                 text: i18n.ukArmedForceCard,
+                id: "uk-armed-forces-veteran-card",
                 attributes: {
-                    "data-event-id": "ukArmedForceCard"
+                    "data-event-id": "UK HM Armed Forces Veteran Card"
                 }
             },
             {
                 value: "ukFrontierPermit",
                 text: i18n.ukFrontierPermit,
+                id: "uk-frontier-worker-permit",
                 attributes: {
-                    "data-event-id": "ukFrontierPermit"
+                    "data-event-id": "UK Frontier worker permit"
                 }
             },
             {
                 value: "photoWorkPermit",
                 text: i18n.photoWorkPermit,
+                id: "photo-work-permit",
                 attributes: {
-                    "data-event-id": "photoWorkPermit"
+                    "data-event-id": "Photographic work permit (government issued)"
                 }
             },
             {
                 value: "photoimmigrationDoc",
                 text: i18n.photoimmigrationDoc,
+                id: "photo-immigration-doc",
                 attributes: {
-                    "data-event-id": "photoimmigrationDoc"
+                    "data-event-id": "Photographic immigration document"
                 }
             },
             {
                 value: "photoVisa",
                 text: i18n.photoVisa,
+                id: "photo-visa",
                 attributes: {
-                    "data-event-id": "photoVisa"
+                    "data-event-id": "Photographic visa"
                 }
             },
             {
                 value: "ukFirearmsLicence",
                 text: i18n.ukFirearmsLicence,
+                id: "uk-firearms-licence",
                 attributes: {
-                    "data-event-id": "ukFirearmsLicence"
+                    "data-event-id": "UK, Channel Islands and Isle of Man Firearms Licence"
                 }
             },
             {
                 value: "photoIdPrado",
                 text: i18n.photoIdPrado,
+                id: "photo-id-prado",
                 hint: {
                         text: i18n.photoIdPradoHint
                         },
                 attributes: {
-                    "data-event-id": "photoIdPrado"
+                    "data-event-id": "Photographic ID listed on PRADO"
                 }
             }
             ]
@@ -145,81 +160,122 @@ i18n.identityDocumentsIDVTitle %}
             {
                 value: "birthCert",
                 text: i18n.birthCert,
+                id: "birth-cert",
                 attributes: {
-                    "data-event-id": "birthCert"
+                    "data-event-id": "Birth or adoption certificate"
                 }
             },
             {
                 value: "marriageCert",
                 text: i18n.marriageCert,
+                id: "marriage-cert",
                 attributes: {
-                    "data-event-id": "marriageCert"
+                    "data-event-id": "Marriage or civil partnership certificate"
                 }
             },
             {
                 value: "noPhotoimmigrationDoc",
                 text: i18n.noPhotoimmigrationDoc,
+                id: "non-photo-immigration-doc",
                 attributes: {
-                    "data-event-id": "noPhotoimmigrationDoc"
+                    "data-event-id": "Non-photographic immigration document"
                 }
             },
             {
                 value: "noPhotoVisa",
                 text: i18n.noPhotoVisa,
+                id: "non-photo-visa",
                 attributes: {
-                    "data-event-id": "noPhotoVisa"
+                    "data-event-id": "Non-photographic visa"
                 }
             },
             {
                 value: "noPhotoWorkPermit",
                 text: i18n.noPhotoWorkPermit,
+                id: "non-photo-work-permit",
                 attributes: {
-                    "data-event-id": "noPhotoWorkPermit"
+                    "data-event-id": "Non-photographic work permit"
                 }
             },
             {
                 value: "bankStatement",
                 text: i18n.bankStatement,
+                id: "bank-statement",
                 attributes: {
-                    "data-event-id": "bankStatement"
+                    "data-event-id": "Bank or building society statement"
                 }
             },
             {
                 value: "rentalAgreement",
                 text: i18n.rentalAgreement,
+                id: "rental-agreement",
                 attributes: {
-                    "data-event-id": "rentalAgreement"
+                    "data-event-id": "UK local authority or social housing rental agreement (for the person's current address)"
                 }
             },
             {
                 value: "morgageStatement",
                 text: i18n.morgageStatement,
+                id: "mortgage-statement",
                 attributes: {
-                    "data-event-id": "morgageStatement"
+                    "data-event-id": "Mortgage statement (for the person's current address)"
                 }
             },
             {
                 value: "taxStatement",
                 text: i18n.taxStatement,
+                id: "council-tax-statement",
                 attributes: {
-                    "data-event-id": "taxStatement"
+                    "data-event-id": "UK Council Tax statement (for the person's current address)"
                 }
             },
             {
                 value: "utilityBill",
                 text: i18n.utilityBill,
+                id: "utility-bill",
                 attributes: {
-                    "data-event-id": "utilityBill"
+                    "data-event-id": "Utility bill (for the person's current address)"
                 }
             }
             ]
         }) }}
         {{ govukButton({
             text: i18n.Continue,
+            id: "continue-button",
             attributes: {
-                "data-event-id": "CONTINUE - dc1"
+                "data-event-id": "Continue-DC2"
             }
         }) }}
     </form>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+    trackEventBasedOnPageTitle("passport-or-irish-passport-card", "{{title}}", "{{matomoRadioSelection}}", "Passport or Irish passport card");
+    trackEventBasedOnPageTitle("identity-card", "{{title}}", "{{matomoRadioSelection}}", "Identity card with biometric information from the EU, Norway, Iceland or Liechtenstein");
+    trackEventBasedOnPageTitle("uk-biometric-residence-permit", "{{title}}", "{{matomoRadioSelection}}", "UK biometric residence permit (BRP)");
+    trackEventBasedOnPageTitle("uk-biometric-residence-card", "{{title}}", "{{matomoRadioSelection}}", "UK biometric residence card (BRC)");
+    trackEventBasedOnPageTitle("uk-accredited-pass-card", "{{title}}", "{{matomoRadioSelection}}", "UK accredited PASS card");
+    trackEventBasedOnPageTitle("uk-eu-driver-digital-tacograph-card", "{{title}}", "{{matomoRadioSelection}}", "UK or EU driver digital tachograph card");
+    trackEventBasedOnPageTitle("uk-drivers-licence", "{{title}}", "{{matomoRadioSelection}}", "UK, Channel Islands,  Isle of Man, and EU photocard driving license (full or provisional)");
+    trackEventBasedOnPageTitle("uk-forces-id-card", "{{title}}", "{{matomoRadioSelection}}", "UK HM Forces ID card");
+    trackEventBasedOnPageTitle("uk-armed-forces-veteran-card", "{{title}}", "{{matomoRadioSelection}}", "UK HM Armed Forces Veteran Card");
+    trackEventBasedOnPageTitle("uk-frontier-worker-permit", "{{title}}", "{{matomoRadioSelection}}", "UK Frontier worker permit");
+    trackEventBasedOnPageTitle("photo-work-permit", "{{title}}", "{{matomoRadioSelection}}", "Photographic work permit (government issued)");
+    trackEventBasedOnPageTitle("photo-immigration-doc", "{{title}}", "{{matomoRadioSelection}}", "Photographic immigration document");
+    trackEventBasedOnPageTitle("photo-visa", "{{title}}", "{{matomoRadioSelection}}", "Photographic visa");
+    trackEventBasedOnPageTitle("uk-firearms-licence", "{{title}}", "{{matomoRadioSelection}}", "PUK, Channel Islands and Isle of Man Firearms Licence");
+    trackEventBasedOnPageTitle("photo-id-prado", "{{title}}", "{{matomoRadioSelection}}", "Photographic ID listed on PRADO");
+    trackEventBasedOnPageTitle("birth-cert", "{{title}}", "{{matomoRadioSelection}}", "Birth or adoption certificate");
+    trackEventBasedOnPageTitle("marriage-cert", "{{title}}", "{{matomoRadioSelection}}", "Marriage or civil partnership certificate");
+    trackEventBasedOnPageTitle("non-photo-immigration-doc", "{{title}}", "{{matomoRadioSelection}}", "Non-photographic immigration document");
+    trackEventBasedOnPageTitle("non-photo-visa", "{{title}}", "{{matomoRadioSelection}}", "Non-photographic visa");
+    trackEventBasedOnPageTitle("non-photo-work-permit", "{{title}}", "{{matomoRadioSelection}}", "Non-photographic work permit");
+    trackEventBasedOnPageTitle("bank-statement", "{{title}}", "{{matomoRadioSelection}}", "Bank or building society statement");
+    trackEventBasedOnPageTitle("rental-agreement", "{{title}}", "{{matomoRadioSelection}}", "UK local authority or social housing rental agreement (for the person's current address)");
+    trackEventBasedOnPageTitle("mortgage-statement", "{{title}}", "{{matomoRadioSelection}}", "Mortgage statement (for the person's current address)");
+    trackEventBasedOnPageTitle("council-tax-statement", "{{title}}", "{{matomoRadioSelection}}", "UK Council Tax statement (for the person's current address)");
+    trackEventBasedOnPageTitle("utility-bill", "{{title}}", "{{matomoRadioSelection}}", "Utility bill (for the person's current address)");
+    trackEventBasedOnPageTitle("continue-button", "{{title}}", "{{matomoButtonClick}}", "Continue-DC2");
+</script>
 
 {% endblock main_content %}

--- a/src/views/index/home.njk
+++ b/src/views/index/home.njk
@@ -9,7 +9,7 @@
     <p class="govuk-body">{{ i18n.useThisService }}</p>
     <div class="govuk-inset-text">
       {{ i18n.guidePageVerificationServiceNote }}
-      <a href="https://www.gov.uk/guidance/companies-house-identity-verification-standard" id="identity-verification-standard-link" data-event-id="Companies House identity verification standard">{{ i18n.linkGuidePageVerificationService }}</a>.
+      <a href="https://www.gov.uk/guidance/companies-house-identity-verification-standard" id="identity-verification-standard-link">{{ i18n.linkGuidePageVerificationService }}</a>.
     </div>
     <h2 class="govuk-heading-m">{{ i18n.whatYoullNeedHeading }}</h2>
     <p class="govuk-body">{{ i18n.youllNeed }}</p>
@@ -31,7 +31,7 @@
       <li>{{ i18n.checksDate }}</li>
     </ul>
     <p class="govuk-body">{{ i18n.startTimeout }}</p>
-    <button class="govuk-button govuk-button--start" data-module="govuk-button" id="start-now" data-event-id="Start Now" onClick="_paq.push(['trackGoal', '15'])">
+    <button class="govuk-button govuk-button--start" data-module="govuk-button" id="start-now" onClick="_paq.push(['trackGoal', '15'])">
       {{ i18n.startNow }}
       <svg
         class="govuk-button__start-icon"
@@ -45,7 +45,7 @@
       </svg>
     </button>
     <p>
-      {{ i18n.readText }}<a href="https://www.gov.uk/guidance/verify-someones-identity" id="read-the-guidance-verification-link" data-event-id="Guidance about verifying someone's identity for Companies House">{{ i18n.readThe }}</a>.
+      {{ i18n.readText }}<a href="https://www.gov.uk/guidance/verify-someones-identity" id="read-the-guidance-verification-link">{{ i18n.readThe }}</a>.
     </p>
   </form>
 

--- a/src/views/index/home.njk
+++ b/src/views/index/home.njk
@@ -9,7 +9,7 @@
     <p class="govuk-body">{{ i18n.useThisService }}</p>
     <div class="govuk-inset-text">
       {{ i18n.guidePageVerificationServiceNote }}
-      <a href="https://www.gov.uk/guidance/companies-house-identity-verification-standard">{{ i18n.linkGuidePageVerificationService }}</a>.
+      <a href="https://www.gov.uk/guidance/companies-house-identity-verification-standard" id="identity-verification-standard-link" data-event-id="Companies House identity verification standard">{{ i18n.linkGuidePageVerificationService }}</a>.
     </div>
     <h2 class="govuk-heading-m">{{ i18n.whatYoullNeedHeading }}</h2>
     <p class="govuk-body">{{ i18n.youllNeed }}</p>
@@ -31,7 +31,7 @@
       <li>{{ i18n.checksDate }}</li>
     </ul>
     <p class="govuk-body">{{ i18n.startTimeout }}</p>
-    <button class="govuk-button govuk-button--start" data-module="govuk-button" onClick="_paq.push(['trackGoal', '15'])">
+    <button class="govuk-button govuk-button--start" data-module="govuk-button" id="start-now" data-event-id="Start Now" onClick="_paq.push(['trackGoal', '15'])">
       {{ i18n.startNow }}
       <svg
         class="govuk-button__start-icon"
@@ -45,7 +45,15 @@
       </svg>
     </button>
     <p>
-      {{ i18n.readText }}<a href="https://www.gov.uk/guidance/verify-someones-identity" data-event-id="Read the guidance">{{ i18n.readThe }}</a>.
+      {{ i18n.readText }}<a href="https://www.gov.uk/guidance/verify-someones-identity" id="read-the-guidance-verification-link" data-event-id="Guidance about verifying someone's identity for Companies House">{{ i18n.readThe }}</a>.
     </p>
   </form>
+
+<!-- Calling Matomo event function to capture event actions based on page title -->
+<script>
+  trackEventBasedOnPageTitle("identity-verification-standard-link", "{{title}}", "{{matomoLinkClick}}", "Companies House identity verification standard");
+  trackEventBasedOnPageTitle("read-the-guidance-verification-link", "{{title}}", "{{matomoLinkClick}}", "Guidance about verifying someone's identity for Companies House");
+  trackEventBasedOnPageTitle("start-now", "{{title}}", "{{matomoButtonClick}}", "Start Now");
+</script>
+
 {% endblock %}

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -36,6 +36,5 @@
       </main>
     </div>
     {% include "partials/__footer.njk" %}
-    {% include "partials/piwik.njk" %}
   </body>
 </html>

--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -26,30 +26,15 @@
             ]
           }
         }) }}
-     <!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//matomo.identity.aws.chdev.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '1']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
+
+<script type="application/javascript">
+  window.SERVICE_NAME = "Tell Companies House you have verified someone's identity";
+  window.PIWIK_URL = '{{ PIWIK_URL }}'
+  window.PIWIK_SITE_ID = '{{ PIWIK_SITE_ID }}'
 </script>
-<!-- End Matomo Code -->
-</footer>
 
 <script src="{{ cdnHost }}/javascripts/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.js"></script>
 <script src="{{ cdnHost }}/javascripts/app/cookie-consent/cookie-consent-1.0.0.js"></script>
-<script src="{{ cdnHost }}/javascripts/app/cookie-consent/piwik-only-cookie-consent.js"></script>
+<script src="{{ cdnHost }}/javascripts/app/cookie-consent/matomo-only-cookie-consent.js"></script>
 <script src="{{ cdnHost }}/javascripts/vendor/jquery-3.3.1.min.js"></script>
-<!--<script src="/all.js"></script>-->
 <script>window.GOVUKFrontend.initAll()</script>
-
-
-
-

--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -26,7 +26,17 @@
             ]
           }
         }) }}
+        
+        {% set templateTitle = title %}
+        {% if "s email address?" in title %}
+            {% set templateTitle = "What is User's email address?" %}
+        {% endif %}
+        {% if "s personal code" in title %}
+            {% set templateTitle = "User's personal code" %}
+        {% endif %}
 
+
+<div id="templateName" data-id='{{templateTitle}}' hidden></div>
 <script type="application/javascript">
   window.SERVICE_NAME = "Tell Companies House you have verified someone's identity";
   window.PIWIK_URL = '{{ PIWIK_URL }}'

--- a/src/views/partials/__meta_header.njk
+++ b/src/views/partials/__meta_header.njk
@@ -14,4 +14,6 @@
     <script>
         var page = page || {};
     </script>
+    <!-- Matomo script to run function trackEventBasedOnPageTitle on each page -->
+    {% include "partials/piwik.njk" %}
 </head>

--- a/src/views/partials/piwik.njk
+++ b/src/views/partials/piwik.njk
@@ -1,5 +1,5 @@
 <script src="{{ cdnHost }}/javascripts/app/piwik-enable.js"></script>
-<div id="templateName" data-id='{{templateName}}' hidden></div>
+
 <!-- Matomo -->
 <script>
     var _paq = window._paq = window._paq || [];

--- a/src/views/partials/piwik.njk
+++ b/src/views/partials/piwik.njk
@@ -1,21 +1,35 @@
 <script src="{{ cdnHost }}/javascripts/app/piwik-enable.js"></script>
-<script type="application/javascript">
-    const journeyTypes = {
-        "register-company": "Register"
-    };
-    
-    const uri = window.location.href;
-    const journeyFromUri = journeyTypes[uri.replace(/^(https?:\/\/)?/, '').split('/')[1]];
-
-    window.SERVICE_NAME = "Tell Companies House you have verified someones identity";
-    window.PIWIK_URL = '{{ PIWIK_URL }}'
-    window.PIWIK_SITE_ID = '{{ PIWIK_SITE_ID }}'
-</script>
 <div id="templateName" data-id='{{templateName}}' hidden></div>
-<script src="{{ cdnHost }}/javascripts/app/cookie-consent/cookie-consent-1.0.0.js"></script>
-<script src="{{ cdnHost }}/javascripts/app/cookie-consent/matomo-only-cookie-consent.js"></script>
-<noscript>
+<!-- Matomo -->
+<script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    
+    _paq.push(['enableLinkTracking']);
+    (function () {
+      var u = "//matomo.identity.aws.chdev.org/";
+      _paq.push(['setTrackerUrl', u + 'matomo.php']);
+      _paq.push(['setSiteId', '1']);
+      var d = document,
+        g = d.createElement('script'),
+        s = d.getElementsByTagName('script')[0];
+      g.async = true;
+      g.src = u + 'matomo.js';
+      s.parentNode.insertBefore(g, s);
+    })();
+  </script>
+  <noscript>
     <p>
         <img src="{{PIWIK_URL}}/piwik.php?idsite={{PIWIK_SITE_ID}}" style="border:0;" alt="" />
     </p>
 </noscript>
+<script>
+// Function to add event categories based on page title
+function trackEventBasedOnPageTitle(elementId, eventCategory, eventAction, eventName) {
+    document.getElementById(elementId)
+    .addEventListener("click", () => {
+        _paq.push(["trackEvent", eventCategory, eventAction, eventName]);
+    });
+}
+</script>
+<!-- Matomo Ends -->

--- a/src/views/partials/print_button.njk
+++ b/src/views/partials/print_button.njk
@@ -22,8 +22,13 @@
   href: "javascript: window.print()",
   attributes: {
       "id": "print-button",
-      "data-event-id": "print-button"
+      "data-event-id": "Print this page"
   }
 }) }}
 
 <p class="govuk-body govuk-!-font-size-20 check-your-answers-javascript-disabled-text-style">{{i18n.printFromBrowser}}</p>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+  trackEventBasedOnPageTitle("print-button", "{{title}}", "pageview", "Print this page");
+</script>

--- a/src/views/partials/print_button.njk
+++ b/src/views/partials/print_button.njk
@@ -21,8 +21,7 @@
   classes: "govuk-button--secondary",
   href: "javascript: window.print()",
   attributes: {
-      "id": "print-button",
-      "data-event-id": "Print this page"
+      "id": "print-button"
   }
 }) }}
 

--- a/src/views/personal-code/personal-code.njk
+++ b/src/views/personal-code/personal-code.njk
@@ -32,10 +32,7 @@
         </details>
         {{ govukButton({
             text: i18n.Continue,
-            id: "continue-button",
-            attributes: {
-                "data-event-id": "Continue-PC"
-            }
+            id: "continue-button"
         }) }}
     </form>
 

--- a/src/views/personal-code/personal-code.njk
+++ b/src/views/personal-code/personal-code.njk
@@ -32,9 +32,18 @@
         </details>
         {{ govukButton({
             text: i18n.Continue,
+            id: "continue-button",
             attributes: {
-                "data-event-id": "CONTINUE - CODE"
+                "data-event-id": "Continue-PC"
             }
         }) }}
     </form>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+    // Overriding page title to remove user's personal details
+    _paq.push(["setDocumentTitle", "User's " + "{{i18n.codePageTitle}}" + " - Tell Companies House you have verified someone’s identity"]);
+    trackEventBasedOnPageTitle("continue-button", "User's " + "{{i18n.codePageTitle}}" + " - Tell Companies House you have verified someone’s identity", "{{matomoButtonClick}}", "Continue-PC");
+</script>
+
 {% endblock main_content %}

--- a/src/views/persons-email/persons-email.njk
+++ b/src/views/persons-email/persons-email.njk
@@ -46,9 +46,18 @@
         </div>
         {{ govukButton({
             text: i18n.Continue,
+            id: "continue-button",
             attributes: {
-              "data-event-id": "CONTINUE - EMAIL"
+              "data-event-id": "Continue-EA"
             }
         }) }}
     </form>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+    // Overriding page title to remove user's personal details
+    _paq.push(["setDocumentTitle", "User" + "{{i18n.emailAddress}}" + " - Tell Companies House you have verified someone’s identity"]);
+    trackEventBasedOnPageTitle("continue-button", "User" + "{{i18n.emailAddress}}" + " - Tell Companies House you have verified someone’s identity", "{{matomoButtonClick}}", "Continue-EA");
+</script>
+
 {% endblock main_content %}

--- a/src/views/persons-email/persons-email.njk
+++ b/src/views/persons-email/persons-email.njk
@@ -46,10 +46,7 @@
         </div>
         {{ govukButton({
             text: i18n.Continue,
-            id: "continue-button",
-            attributes: {
-              "data-event-id": "Continue-EA"
-            }
+            id: "continue-button"
         }) }}
     </form>
 

--- a/src/views/persons-name/persons-name.njk
+++ b/src/views/persons-name/persons-name.njk
@@ -52,9 +52,16 @@
         </div>
         {{ govukButton({
             text: i18n.Continue,
+            id: "continue-button",
             attributes: {
-              "data-event-id": "CONTINUE - NAME"
+                "data-event-id": "Continue-name"
             }
         }) }}
     </form>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+    trackEventBasedOnPageTitle("continue-button", "{{title}}" + " - Tell Companies House you have verified someone’s identity", "{{matomoButtonClick}}", "Continue-name");
+</script>
+
 {% endblock main_content %}

--- a/src/views/persons-name/persons-name.njk
+++ b/src/views/persons-name/persons-name.njk
@@ -52,10 +52,7 @@
         </div>
         {{ govukButton({
             text: i18n.Continue,
-            id: "continue-button",
-            attributes: {
-                "data-event-id": "Continue-name"
-            }
+            id: "continue-button"
         }) }}
     </form>
 

--- a/src/views/sign-out-page/sign-out.njk
+++ b/src/views/sign-out-page/sign-out.njk
@@ -30,18 +30,12 @@
 				{
 					value: "yes",
 					text: i18n.signoutYesButtonText,
-					id: "signout-yes",
-					attributes: {
-						"data-event-id": "Signout-yes"
-					}
+					id: "signout-yes"
 				},
 				{
 					value: "no",
 					text: i18n.signoutNoButtonText,
-					id: "signout-no",
-					attributes: {
-						"data-event-id": "Signout-no"
-					}
+					id: "signout-no"
 				}
 			]
 		}) }}
@@ -49,7 +43,7 @@
 			summaryText: i18n.signoutHowHintText,
 			text: i18n.signoutHowHintDetailsText
 		}) }}
-		<button class="govuk-button" id="save-and-continue" data-event-id="Save and continue">{{ i18n.SaveAndContinue }}</button>
+		<button class="govuk-button" id="save-and-continue">{{ i18n.SaveAndContinue }}</button>
 	</form>
 
 <!-- Calling Matomo event script to capture event actions based on page title -->

--- a/src/views/sign-out-page/sign-out.njk
+++ b/src/views/sign-out-page/sign-out.njk
@@ -29,16 +29,18 @@
 			items: [
 				{
 					value: "yes",
-					text: i18n.signoutYesButtonText, 
+					text: i18n.signoutYesButtonText,
+					id: "signout-yes",
 					attributes: {
-						"data-event-id": "signout-yes"
+						"data-event-id": "Signout-yes"
 					}
 				},
 				{
 					value: "no",
 					text: i18n.signoutNoButtonText,
+					id: "signout-no",
 					attributes: {
-						"data-event-id": "signout-no"
+						"data-event-id": "Signout-no"
 					}
 				}
 			]
@@ -47,8 +49,16 @@
 			summaryText: i18n.signoutHowHintText,
 			text: i18n.signoutHowHintDetailsText
 		}) }}
-		<button class="govuk-button">{{ i18n.SaveAndContinue }}</button>
+		<button class="govuk-button" id="save-and-continue" data-event-id="Save and continue">{{ i18n.SaveAndContinue }}</button>
 	</form>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+	    trackEventBasedOnPageTitle("signout-yes", "{{title}}", "{{matomoRadioSelect}}", "Signout-yes");
+		trackEventBasedOnPageTitle("signout-no", "{{title}}", "{{matomoRadioSelect}}", "Signout-no");
+		trackEventBasedOnPageTitle("save-and-continue", "{{title}}", "{{matomoButtonClick}}", "Save and continue");
+</script>
+
 {% endblock main_content %}
 
 

--- a/src/views/what-is-their-date-of-birth/what-is-their-date-of-birth.njk
+++ b/src/views/what-is-their-date-of-birth/what-is-their-date-of-birth.njk
@@ -88,10 +88,17 @@
 
       {{ govukButton({
         text: i18n.Continue,
+        id: "continue-button",
         attributes: {
-          "data-event-id": "CONTINUE - DOB"
+          "data-event-id": "Continue-DOB"
         }
       }) }}
     </form>
   </div>
+
+<!-- Calling Matomo event script to capture event actions based on page title -->
+<script>
+  trackEventBasedOnPageTitle("continue-button", "{{title}}" + " - Tell Companies House you have verified someone’s identity", "{{matomoButtonClick}}", "Continue-DOB");
+</script>
+
 {% endblock main_content %}

--- a/src/views/what-is-their-date-of-birth/what-is-their-date-of-birth.njk
+++ b/src/views/what-is-their-date-of-birth/what-is-their-date-of-birth.njk
@@ -88,10 +88,7 @@
 
       {{ govukButton({
         text: i18n.Continue,
-        id: "continue-button",
-        attributes: {
-          "data-event-id": "Continue-DOB"
-        }
+        id: "continue-button"
       }) }}
     </form>
   </div>


### PR DESCRIPTION
1. Script added to piwik.njk and function created to display Matomo events based on page titles.
2. Moved piwik.njk from _footer.njk to call script through __meta_header.njk on each page.
3. Calling trackEventBasedOnPageTitle() function on the relevant .njk files to register button clicks based on page title.
4. Adding new constant values for button/link/radio clicks to constants.ts to be called in the above function.
5. Importing constants on /controllers for each page.
6. Creating custom page titles on personal-code.njk and persons-email.njk to exclude identifiable user details on Matomo analytics dashboard.
7. Updating/creating id values on .njk files to include as parameters on trackEventBasedOnPageTitle() function.
8. Removing duplicate data-event-ids from buttons/links on .njk files, to prevent event actions from displaying twice on Matomo

