### PR TITLE
Adding kickout screen for when email is already been used

### DIFF
--- a/locales/cy/provide-different-email.json
+++ b/locales/cy/provide-different-email.json
@@ -1,0 +1,9 @@
+{
+    "provideDifferentEmailTitle": "You need to provide a different email address welsh",
+    "cannotUseDynamicEmail": "You cannot use welsh ",
+    "invalidEmailReasonsLabel": "This could be for one of the following reasons: welsh",
+    "invalidEmailReasons1": "an authorised agent already provided this email address when they verified someone's identity welsh",
+    "invalidEmailReasons2": "someone has used this email address to verify their identity using GOV.UK One Login welsh",
+    "youNeedTo": "You'll need to welsh ",
+    "provideDifferentEmailLink": "provide a different email address for welsh "
+}

--- a/locales/en/provide-different-email.json
+++ b/locales/en/provide-different-email.json
@@ -1,0 +1,9 @@
+{
+    "provideDifferentEmailTitle": "You need to provide a different email address",
+    "cannotUseDynamicEmail": "You cannot use ",
+    "invalidEmailReasonsLabel": "This could be for one of the following reasons:",
+    "invalidEmailReasons1": "an authorised agent already provided this email address when they verified someone's identity",
+    "invalidEmailReasons2": "someone has used this email address to verify their identity using GOV.UK One Login",
+    "youNeedTo": "You'll need to ",
+    "provideDifferentEmailLink": "provide a different email address for "
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -21,6 +21,7 @@ export const PERSONS_NAME = `${BASE_VIEWS_URL}/persons-name/persons-name`;
 export const PERSONAL_CODE = `${BASE_VIEWS_URL}/personal-code/personal-code`;
 export const DATE_OF_BIRTH = `${BASE_VIEWS_URL}/what-is-their-date-of-birth/what-is-their-date-of-birth`;
 export const PERSONS_EMAIL = `${BASE_VIEWS_URL}/persons-email/persons-email`;
+export const PROVIDE_DIFFERENT_EMAIL = `${BASE_VIEWS_URL}/provide-different-email/provide-different-email`;
 
 export const HOME_ADDRESS_MANUAL = `${BASE_VIEWS_URL}/home-address-manual/home-address-manual`;
 export const HOME_ADDRESS_LIST = `${BASE_VIEWS_URL}/home-address-list/home-address-list`;

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -11,6 +11,7 @@ export * as dateOfBirthController from "./dateOfBirthController";
 export * as identityDocumentsCheckedGroup1Controller from "./identityDocumentsCheckedGroup1Controller";
 export * as identityDocumentsCheckedGroup2Controller from "./identityDocumentsCheckedGroup2Controller";
 export * as personsEmailController from "./personsEmailController";
+export * as provideDifferentEmailController from "./provideDifferentEmailController";
 export * as howIdentityDocumentsCheckedController from "./howIdentityDocumentsCheckedController";
 export * as whenIdentityChecksCompletedController from "./whenIdentityChecksCompletedController";
 export * as checkYourAnswersController from "./checkYourAnswers";

--- a/src/controllers/provideDifferentEmailController.ts
+++ b/src/controllers/provideDifferentEmailController.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from "express";
+import { BASE_URL, PROVIDE_DIFFERENT_EMAIL, EMAIL_ADDRESS } from "../types/pageURL";
+import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
+import { Session } from "@companieshouse/node-session-handler";
+import { ClientData } from "model/ClientData";
+import { USER_DATA } from "../utils/constants";
+import * as config from "../config";
+
+export const get = async (req: Request, res: Response, next: NextFunction) => {
+    const lang = selectLang(req.query.lang);
+    const session: Session = req.session as any as Session;
+    const clientData: ClientData = session.getExtraData(USER_DATA)!;
+
+    res.render(config.PROVIDE_DIFFERENT_EMAIL, {
+        ...getLocaleInfo(getLocalesService(), lang),
+        currentUrl: BASE_URL + PROVIDE_DIFFERENT_EMAIL,
+        previousPage: addLangToUrl(BASE_URL + EMAIL_ADDRESS, lang),
+        firstName: clientData?.firstName,
+        lastName: clientData?.lastName,
+        emailAddress: clientData?.emailAddress
+    });
+};

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -18,7 +18,8 @@ import {
     checkYourAnswersController,
     confirmIdentityVerificationController,
     signOutController,
-    confirmationController
+    confirmationController,
+    provideDifferentEmailController
 } from "../controllers";
 
 import * as urls from "../types/pageURL";
@@ -79,6 +80,8 @@ routes.post(urls.WHEN_IDENTITY_CHECKS_COMPLETED, dateValidator("wicc"), whenIden
 
 routes.get(urls.EMAIL_ADDRESS, personsEmailController.get);
 routes.post(urls.EMAIL_ADDRESS, emailValidator, personsEmailController.post);
+
+routes.get(urls.PROVIDE_DIFFERENT_EMAIL, provideDifferentEmailController.get);
 
 routes.get(urls.CONFIRM_IDENTITY_VERIFICATION, confirmIdentityVerificationController.get);
 routes.post(urls.CONFIRM_IDENTITY_VERIFICATION, confirmIdentityVerificationValidator, confirmIdentityVerificationController.post);

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -22,6 +22,8 @@ export const PERSONAL_CODE = "/companies-house-personal-code";
 
 export const EMAIL_ADDRESS = "/what-is-their-email-address";
 
+export const PROVIDE_DIFFERENT_EMAIL = "/provide-different-email";
+
 export const DATE_OF_BIRTH = "/what-is-their-date-of-birth";
 
 export const HOME_ADDRESS = "/what-is-their-home-address";

--- a/src/views/provide-different-email/provide-different-email.njk
+++ b/src/views/provide-different-email/provide-different-email.njk
@@ -1,0 +1,22 @@
+{% extends "layouts/default.njk" %}
+{% set title = i18n.provideDifferentEmailTitle %}
+{% block main_content %}
+
+    <h1 class="govuk-heading-l">{{ i18n.provideDifferentEmailTitle }}</h1>
+    <p class="govuk-body">{{ i18n.cannotUseDynamicEmail }}<strong>{{ emailAddress }}</strong>.</p>
+    <p class="govuk-body">{{ i18n.invalidEmailReasonsLabel }}</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>{{ i18n.invalidEmailReasons1 }}</li>
+      <li>{{ i18n.invalidEmailReasons2 }}</li>
+    </ul>
+    
+    <p class="govuk-body">
+        {{ i18n.youNeedTo }}
+        <a id="provide-different-email-link-id" href="/tell-companies-house-you-have-verified-someones-identity/what-is-their-email-address">{{ i18n.provideDifferentEmailLink }}{{ firstName }} {{ lastName }}</a>.
+    </p>
+
+    <script>
+        trackEventBasedOnPageTitle("provide-different-email-link-id", "{{title}}", "click-link", "provide different email link");
+    </script>
+
+{% endblock main_content %}

--- a/test/src/controllers/provideDifferentEmailController.test.ts
+++ b/test/src/controllers/provideDifferentEmailController.test.ts
@@ -1,0 +1,16 @@
+import mocks from "../../mocks/all_middleware_mock";
+import supertest from "supertest";
+import app from "../../../src/app";
+import { BASE_URL, PROVIDE_DIFFERENT_EMAIL } from "../../../src/types/pageURL";
+
+const router = supertest(app);
+
+describe("GET " + PROVIDE_DIFFERENT_EMAIL, () => {
+    it("should respond with status 200", async () => {
+        const res = await router.get(BASE_URL + PROVIDE_DIFFERENT_EMAIL);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        expect(res.text).toContain("You need to provide a different email address");
+    });
+});

--- a/test/src/controllers/provideDifferentEmailController.test.ts
+++ b/test/src/controllers/provideDifferentEmailController.test.ts
@@ -7,7 +7,12 @@ const router = supertest(app);
 
 describe("GET " + PROVIDE_DIFFERENT_EMAIL, () => {
     it("should respond with status 200", async () => {
-        const res = await router.get(BASE_URL + PROVIDE_DIFFERENT_EMAIL);
+        const res = await router.get(BASE_URL + PROVIDE_DIFFERENT_EMAIL)
+            .send({
+                "first-name": "John",
+                "last-name": "Doe",
+                "email-address": "johndoe@gmail.com"
+            });
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
         expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
         expect(res.status).toBe(200);


### PR DESCRIPTION
**Short description outlining key changes/additions**

Previously there was a frontend validation message being thrown when the email was already in use.

I added a new kickout screen so when an email is already being used it redirects to this screen as per the prototype.

**JIRA Ticket Number**

[IDVA5-1134](https://companieshouse.atlassian.net/browse/IDVA5-1134)

**Type of change**
 
- [ ] Bug fix
- [X]  New feature
- [ ]  Breaking change
- [ ]  Infrastructure change

**Pull request checklist**

- [X]  I have added unit tests for new code that I have added
- [ ]  I have added/updated functional tests where appropriate
- [X]  The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

**An exhaustive list of peer review checks can be read** [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)

[IDVA5-1134]: https://companieshouse.atlassian.net/browse/IDVA5-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ