### PR TITLE
IDVA5-1313 Return to check your answers

### DIFF
--- a/src/controllers/checkYourAnswers.ts
+++ b/src/controllers/checkYourAnswers.ts
@@ -93,9 +93,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const identityVerificationService = new IdentityVerificationService();
         const verifiedClientData = identityVerificationService.prepareVerifiedClientData(clientData);
 
-        // Deleting CYA flag once journey is completed
-        session.deleteExtraData(CHECK_YOUR_ANSWERS_FLAG);
-
         await sendVerifiedClientDetails(verifiedClientData).then(identity => {
             logger.info("response from verification api" + JSON.stringify(identity));
             saveDataInSession(req, REFERENCE, identity?.id);

--- a/src/controllers/confirmHomeAddressController.ts
+++ b/src/controllers/confirmHomeAddressController.ts
@@ -1,9 +1,9 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
-import { HOME_ADDRESS, BASE_URL, CONFIRM_HOME_ADDRESS, WHEN_IDENTITY_CHECKS_COMPLETED, HOME_ADDRESS_MANUAL } from "../types/pageURL";
+import { HOME_ADDRESS, BASE_URL, CONFIRM_HOME_ADDRESS, WHEN_IDENTITY_CHECKS_COMPLETED, HOME_ADDRESS_MANUAL, CHECK_YOUR_ANSWERS } from "../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_LINK_CLICK } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_LINK_CLICK, CHECK_YOUR_ANSWERS_FLAG } from "../utils/constants";
 import { ClientData } from "model/ClientData";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -27,5 +27,13 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
-    res.redirect(addLangToUrl(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED, lang));
+    const session: Session = req.session as any as Session;
+
+    const checkYourAnswersFlag = session?.getExtraData(CHECK_YOUR_ANSWERS_FLAG);
+
+    if (checkYourAnswersFlag) {
+        res.redirect(addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang));
+    } else {
+        res.redirect(addLangToUrl(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED, lang));
+    }
 };

--- a/src/controllers/dateOfBirthController.ts
+++ b/src/controllers/dateOfBirthController.ts
@@ -2,18 +2,18 @@ import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../validations/validation";
-import { BASE_URL, DATE_OF_BIRTH, EMAIL_ADDRESS, HOME_ADDRESS } from "../types/pageURL";
+import { BASE_URL, DATE_OF_BIRTH, EMAIL_ADDRESS, HOME_ADDRESS, CHECK_YOUR_ANSWERS } from "../types/pageURL";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
-import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, PREVIOUS_PAGE_URL } from "../utils/constants";
 import { ClientData } from "model/ClientData";
 import { saveDataInSession } from "../utils/sessionHelper";
+import { getPreviousPageUrl } from "../services/url";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
     const session: Session = req.session as any as Session;
-    const previousPage: string = addLangToUrl(BASE_URL + EMAIL_ADDRESS, lang);
     const currentUrl: string = BASE_URL + DATE_OF_BIRTH;
 
     const clientData: ClientData = session.getExtraData(USER_DATA) ? session.getExtraData(USER_DATA)! : {};
@@ -27,6 +27,14 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             "dob-day": dateOfBirth.getDate()
         };
     }
+
+    const previousPageUrl = getPreviousPageUrl(req, BASE_URL);
+    saveDataInSession(req, PREVIOUS_PAGE_URL, previousPageUrl);
+
+    const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        : addLangToUrl(BASE_URL + EMAIL_ADDRESS, lang);
+
     res.render(config.DATE_OF_BIRTH, {
         ...getLocaleInfo(locales, lang),
         previousPage,
@@ -45,7 +53,12 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 
     const session: Session = req.session as any as Session;
     const clientData: ClientData = session?.getExtraData(USER_DATA)!;
-    const previousPage: string = addLangToUrl(BASE_URL + EMAIL_ADDRESS, lang);
+    const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+
+    const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        : addLangToUrl(BASE_URL + EMAIL_ADDRESS, lang);
+
     const errorList = validationResult(req);
     if (!errorList.isEmpty()) {
         const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
@@ -67,6 +80,13 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             );
             clientData.dateOfBirth = dateOfBirth;
         }
-        res.redirect(addLangToUrl(BASE_URL + HOME_ADDRESS, lang));
+
+        const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+
+        if (previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)) {
+            res.redirect(addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang));
+        } else {
+            res.redirect(addLangToUrl(BASE_URL + HOME_ADDRESS, lang));
+        }
     }
 };

--- a/src/controllers/dateOfBirthController.ts
+++ b/src/controllers/dateOfBirthController.ts
@@ -81,8 +81,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             clientData.dateOfBirth = dateOfBirth;
         }
 
-        const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
-
         if (previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)) {
             res.redirect(addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang));
         } else {

--- a/src/controllers/homeAddressController.ts
+++ b/src/controllers/homeAddressController.ts
@@ -1,3 +1,4 @@
+/* eslint-disable indent */
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
 import { DATE_OF_BIRTH, HOME_ADDRESS_MANUAL, HOME_ADDRESS, BASE_URL, CHOOSE_AN_ADDRESS, CONFIRM_HOME_ADDRESS, CHECK_YOUR_ANSWERS } from "../types/pageURL";

--- a/src/controllers/homeAddressController.ts
+++ b/src/controllers/homeAddressController.ts
@@ -1,13 +1,13 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
-import { DATE_OF_BIRTH, HOME_ADDRESS_MANUAL, HOME_ADDRESS, BASE_URL, CHOOSE_AN_ADDRESS, CONFIRM_HOME_ADDRESS } from "../types/pageURL";
+import { DATE_OF_BIRTH, HOME_ADDRESS_MANUAL, HOME_ADDRESS, BASE_URL, CHOOSE_AN_ADDRESS, CONFIRM_HOME_ADDRESS, CHECK_YOUR_ANSWERS } from "../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 import { formatValidationError, getPageProperties } from "../validations/validation";
 import { ValidationError, validationResult } from "express-validator";
 import { Session } from "@companieshouse/node-session-handler";
 import { ClientData } from "model/ClientData";
 import { AddressLookUpService } from "../services/addressLookup";
-import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_LINK_CLICK } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_LINK_CLICK, PREVIOUS_PAGE_URL } from "../utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
@@ -20,9 +20,15 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         premise: clientData.address?.propertyDetails
     };
 
+    const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+
+    const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        : addLangToUrl(BASE_URL + DATE_OF_BIRTH, lang);
+
     res.render(config.HOME_ADDRESS, {
         ...getLocaleInfo(locales, lang),
-        previousPage: addLangToUrl(BASE_URL + DATE_OF_BIRTH, lang),
+        previousPage: previousPage,
         AddressManualLink: addLangToUrl(BASE_URL + HOME_ADDRESS_MANUAL, lang),
         currentUrl: BASE_URL + HOME_ADDRESS,
         matomoButtonClick: MATOMO_BUTTON_CLICK,
@@ -37,11 +43,17 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
     const errorList = validationResult(req);
-    const previousPage = addLangToUrl(BASE_URL + DATE_OF_BIRTH, lang);
     const currentUrl = BASE_URL + HOME_ADDRESS;
     const AddressManualLink = addLangToUrl(BASE_URL + HOME_ADDRESS_MANUAL, lang);
     const session: Session = req.session as any as Session;
     const clientData: ClientData = session?.getExtraData(USER_DATA)!;
+
+    const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+
+    const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        : addLangToUrl(BASE_URL + DATE_OF_BIRTH, lang);
+
     if (!errorList.isEmpty()) {
         const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
         res.status(400).render(config.HOME_ADDRESS, {
@@ -60,25 +72,25 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const addressLookUpService = new AddressLookUpService();
         await addressLookUpService.getAddressFromPostcode(req, postcode, inputPremise, clientData,
             CONFIRM_HOME_ADDRESS, CHOOSE_AN_ADDRESS).then(async (nextPageUrl) => {
-            res.redirect(nextPageUrl);
-        }).catch(() => {
-            const validationError: ValidationError[] = [{
-                value: postcode,
-                msg: "homeAddressNoPostcodeFound",
-                param: "postCode",
-                location: "body"
-            }];
-            const pageProperties = getPageProperties(formatValidationError(validationError, lang));
-            res.status(400).render(config.HOME_ADDRESS, {
-                previousPage,
-                ...getLocaleInfo(locales, lang),
-                currentUrl,
-                ...pageProperties,
-                payload: req.body,
-                AddressManualLink,
-                firstName: clientData?.firstName,
-                lastName: clientData?.lastName
+                res.redirect(nextPageUrl);
+            }).catch(() => {
+                const validationError: ValidationError[] = [{
+                    value: postcode,
+                    msg: "homeAddressNoPostcodeFound",
+                    param: "postCode",
+                    location: "body"
+                }];
+                const pageProperties = getPageProperties(formatValidationError(validationError, lang));
+                res.status(400).render(config.HOME_ADDRESS, {
+                    previousPage,
+                    ...getLocaleInfo(locales, lang),
+                    currentUrl,
+                    ...pageProperties,
+                    payload: req.body,
+                    AddressManualLink,
+                    firstName: clientData?.firstName,
+                    lastName: clientData?.lastName
+                });
             });
-        });
     }
 };

--- a/src/controllers/howIdentityDocumentsCheckedController.ts
+++ b/src/controllers/howIdentityDocumentsCheckedController.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
-import { HOW_IDENTITY_DOCUMENTS_CHECKED, WHEN_IDENTITY_CHECKS_COMPLETED, WHICH_IDENTITY_DOCS_CHECKED_GROUP1, BASE_URL, WHICH_IDENTITY_DOCS_CHECKED_GROUP2 } from "../types/pageURL";
+import { HOW_IDENTITY_DOCUMENTS_CHECKED, WHEN_IDENTITY_CHECKS_COMPLETED, WHICH_IDENTITY_DOCS_CHECKED_GROUP1, BASE_URL, WHICH_IDENTITY_DOCS_CHECKED_GROUP2, CHECK_YOUR_ANSWERS } from "../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 import { formatValidationError, getPageProperties } from "../validations/validation";
 import { validationResult } from "express-validator";
@@ -8,7 +8,6 @@ import { Session } from "@companieshouse/node-session-handler";
 import { ClientData } from "model/ClientData";
 import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT, PREVIOUS_PAGE_URL } from "../utils/constants";
 import { saveDataInSession } from "../utils/sessionHelper";
-import { getPreviousPageUrl } from "../services/url";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
@@ -16,12 +15,15 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     const session: Session = req.session as any as Session;
     const clientData: ClientData = session.getExtraData(USER_DATA) ? session.getExtraData(USER_DATA)! : {};
 
-    const previousPageUrl = getPreviousPageUrl(req, BASE_URL);
-    saveDataInSession(req, PREVIOUS_PAGE_URL, previousPageUrl);
+    const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+
+    const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        : addLangToUrl(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED, lang);
 
     res.render(config.HOW_IDENTITY_DOCUMENTS_CHECKED, {
         ...getLocaleInfo(locales, lang),
-        previousPage: addLangToUrl(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED, lang),
+        previousPage: previousPage,
         currentUrl: BASE_URL + HOW_IDENTITY_DOCUMENTS_CHECKED,
         selectedOption: clientData?.howIdentityDocsChecked,
         matomoButtonClick: MATOMO_BUTTON_CLICK,
@@ -39,9 +41,15 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const errorList = validationResult(req);
     const selectedOption = req.body.howIdentityDocsCheckedRadio;
     if (!errorList.isEmpty()) {
+        const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+
+        const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+            ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+            : addLangToUrl(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED, lang);
+
         const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
         res.status(400).render(config.HOW_IDENTITY_DOCUMENTS_CHECKED, {
-            previousPage: addLangToUrl(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED, lang),
+            previousPage: previousPage,
             ...getLocaleInfo(locales, lang),
             currentUrl: BASE_URL + HOW_IDENTITY_DOCUMENTS_CHECKED,
             ...pageProperties,
@@ -50,6 +58,10 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             lastName: clientData?.lastName
         });
     } else {
+        const storedOptionSelection = clientData.howIdentityDocsChecked;
+        if (storedOptionSelection !== selectedOption) {
+            clientData.documentsChecked = [];
+        }
         clientData.howIdentityDocsChecked = selectedOption;
         saveDataInSession(req, USER_DATA, clientData);
         if (selectedOption === "cryptographic_security_features_checked") {

--- a/src/controllers/howIdentityDocumentsCheckedController.ts
+++ b/src/controllers/howIdentityDocumentsCheckedController.ts
@@ -6,14 +6,18 @@ import { formatValidationError, getPageProperties } from "../validations/validat
 import { validationResult } from "express-validator";
 import { Session } from "@companieshouse/node-session-handler";
 import { ClientData } from "model/ClientData";
-import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT, PREVIOUS_PAGE_URL } from "../utils/constants";
 import { saveDataInSession } from "../utils/sessionHelper";
+import { getPreviousPageUrl } from "../services/url";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
     const session: Session = req.session as any as Session;
     const clientData: ClientData = session.getExtraData(USER_DATA) ? session.getExtraData(USER_DATA)! : {};
+
+    const previousPageUrl = getPreviousPageUrl(req, BASE_URL);
+    saveDataInSession(req, PREVIOUS_PAGE_URL, previousPageUrl);
 
     res.render(config.HOW_IDENTITY_DOCUMENTS_CHECKED, {
         ...getLocaleInfo(locales, lang),

--- a/src/controllers/identityDocumentsCheckedGroup1Controller.ts
+++ b/src/controllers/identityDocumentsCheckedGroup1Controller.ts
@@ -3,11 +3,11 @@ import * as config from "../config";
 import { NextFunction, Request, Response } from "express";
 import { BASE_URL, WHICH_IDENTITY_DOCS_CHECKED_GROUP1, HOW_IDENTITY_DOCUMENTS_CHECKED, CONFIRM_IDENTITY_VERIFICATION, CHECK_YOUR_ANSWERS } from "../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
+import { CheckedDocumentsService } from "../services/checkedDocumentsService";
 import { ClientData } from "../model/ClientData";
+import { formatValidationError, getPageProperties } from "../validations/validation";
 import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT, CHECK_YOUR_ANSWERS_FLAG } from "../utils/constants";
 import { validationResult } from "express-validator";
-import { formatValidationError, getPageProperties } from "../validations/validation";
-import { CheckedDocumentsService } from "../services/checkedDocumentsService";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);

--- a/src/controllers/identityDocumentsCheckedGroup1Controller.ts
+++ b/src/controllers/identityDocumentsCheckedGroup1Controller.ts
@@ -1,10 +1,10 @@
 import { Session } from "@companieshouse/node-session-handler";
 import * as config from "../config";
 import { NextFunction, Request, Response } from "express";
-import { BASE_URL, WHICH_IDENTITY_DOCS_CHECKED_GROUP1, HOW_IDENTITY_DOCUMENTS_CHECKED, CONFIRM_IDENTITY_VERIFICATION } from "../types/pageURL";
+import { BASE_URL, WHICH_IDENTITY_DOCS_CHECKED_GROUP1, HOW_IDENTITY_DOCUMENTS_CHECKED, CONFIRM_IDENTITY_VERIFICATION, CHECK_YOUR_ANSWERS } from "../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 import { ClientData } from "../model/ClientData";
-import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT, PREVIOUS_PAGE_URL } from "../utils/constants";
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../validations/validation";
 import { CheckedDocumentsService } from "../services/checkedDocumentsService";
@@ -54,6 +54,14 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     } else {
         const checkedDocumentsService = new CheckedDocumentsService();
         checkedDocumentsService.saveDocuments(req, clientData, req.body.documentsGroup1);
-        res.redirect(addLangToUrl(BASE_URL + CONFIRM_IDENTITY_VERIFICATION, lang));
+
+        const previousPageUrl : string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+        console.log("abc------>", previousPageUrl);
+
+        if (previousPageUrl === "/tell-companies-house-you-have-verified-someones-identity/check-your-answers?lang=en") {
+            res.redirect(addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang));
+        } else {
+            res.redirect(addLangToUrl(BASE_URL + CONFIRM_IDENTITY_VERIFICATION, lang));
+        }
     }
 };

--- a/src/controllers/identityDocumentsCheckedGroup1Controller.ts
+++ b/src/controllers/identityDocumentsCheckedGroup1Controller.ts
@@ -4,7 +4,7 @@ import { NextFunction, Request, Response } from "express";
 import { BASE_URL, WHICH_IDENTITY_DOCS_CHECKED_GROUP1, HOW_IDENTITY_DOCUMENTS_CHECKED, CONFIRM_IDENTITY_VERIFICATION, CHECK_YOUR_ANSWERS } from "../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 import { ClientData } from "../model/ClientData";
-import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT, PREVIOUS_PAGE_URL } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT, CHECK_YOUR_ANSWERS_FLAG } from "../utils/constants";
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../validations/validation";
 import { CheckedDocumentsService } from "../services/checkedDocumentsService";
@@ -55,10 +55,9 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const checkedDocumentsService = new CheckedDocumentsService();
         checkedDocumentsService.saveDocuments(req, clientData, req.body.documentsGroup1);
 
-        const previousPageUrl : string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
-        console.log("abc------>", previousPageUrl);
+        const checkYourAnswersFlag = session?.getExtraData(CHECK_YOUR_ANSWERS_FLAG);
 
-        if (previousPageUrl === "/tell-companies-house-you-have-verified-someones-identity/check-your-answers?lang=en") {
+        if (checkYourAnswersFlag) {
             res.redirect(addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang));
         } else {
             res.redirect(addLangToUrl(BASE_URL + CONFIRM_IDENTITY_VERIFICATION, lang));

--- a/src/controllers/identityDocumentsCheckedGroup2Controller.ts
+++ b/src/controllers/identityDocumentsCheckedGroup2Controller.ts
@@ -2,10 +2,10 @@
 import { Session } from "@companieshouse/node-session-handler";
 import * as config from "../config";
 import { NextFunction, Request, Response } from "express";
-import { BASE_URL, WHICH_IDENTITY_DOCS_CHECKED_GROUP2, HOW_IDENTITY_DOCUMENTS_CHECKED, CONFIRM_IDENTITY_VERIFICATION } from "../types/pageURL";
+import { BASE_URL, WHICH_IDENTITY_DOCS_CHECKED_GROUP2, HOW_IDENTITY_DOCUMENTS_CHECKED, CONFIRM_IDENTITY_VERIFICATION, CHECK_YOUR_ANSWERS } from "../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 import { ClientData } from "../model/ClientData";
-import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, MATOMO_RADIO_OPTION_SELECT, CHECK_YOUR_ANSWERS_FLAG } from "../utils/constants";
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../validations/validation";
 import { CheckedDocumentsService } from "../services/checkedDocumentsService";
@@ -64,6 +64,13 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 
         const checkedDocumentsService = new CheckedDocumentsService();
         checkedDocumentsService.saveDocumentGroupAB(req, clientData, documentsGroup2);
-        res.redirect(addLangToUrl(BASE_URL + CONFIRM_IDENTITY_VERIFICATION, lang));
+
+        const checkYourAnswersFlag = session?.getExtraData(CHECK_YOUR_ANSWERS_FLAG);
+
+        if (checkYourAnswersFlag) {
+            res.redirect(addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang));
+        } else {
+            res.redirect(addLangToUrl(BASE_URL + CONFIRM_IDENTITY_VERIFICATION, lang));
+        }
     }
 };

--- a/src/controllers/personsEmailController.ts
+++ b/src/controllers/personsEmailController.ts
@@ -1,17 +1,18 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
-import { BASE_URL, PERSONAL_CODE, EMAIL_ADDRESS, DATE_OF_BIRTH, PROVIDE_DIFFERENT_EMAIL } from "../types/pageURL";
+import { BASE_URL, PERSONAL_CODE, EMAIL_ADDRESS, DATE_OF_BIRTH, PROVIDE_DIFFERENT_EMAIL, CHECK_YOUR_ANSWERS } from "../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 import { formatValidationError, getPageProperties } from "../validations/validation";
 import { ValidationError, validationResult } from "express-validator";
 import { Session } from "@companieshouse/node-session-handler";
 import { ClientData } from "model/ClientData";
-import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, PREVIOUS_PAGE_URL } from "../utils/constants";
 import { saveDataInSession } from "../utils/sessionHelper";
 import { findIdentityByEmail } from "../services/identityVerificationService";
 import logger from "../lib/Logger";
 import { ErrorService } from "../services/errorService";
 import { LocalesService } from "@companieshouse/ch-node-utils";
+import { getPreviousPageUrl } from "../services/url";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
@@ -24,10 +25,17 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         confirm: clientData?.confirmEmailAddress
     };
 
+    const previousPageUrl = getPreviousPageUrl(req, BASE_URL);
+    saveDataInSession(req, PREVIOUS_PAGE_URL, previousPageUrl);
+
+    const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        : addLangToUrl(BASE_URL + PERSONAL_CODE, lang);
+
     res.render(config.PERSONS_EMAIL, {
         ...getLocaleInfo(locales, lang),
         matomoButtonClick: MATOMO_BUTTON_CLICK,
-        previousPage: addLangToUrl(BASE_URL + PERSONAL_CODE, lang),
+        previousPage: previousPage,
         currentUrl: BASE_URL + EMAIL_ADDRESS,
         payload,
         firstName: clientData?.firstName,
@@ -48,11 +56,18 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         clientData.emailAddress = req.body["email-address"];
         clientData.confirmEmailAddress = req.body.confirm;
         saveDataInSession(req, USER_DATA, clientData);
+
+        const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+
         await findIdentityByEmail(req.body["email-address"]).then(identity => {
             if (identity !== undefined) {
                 res.redirect(addLangToUrl(BASE_URL + PROVIDE_DIFFERENT_EMAIL, lang));
             } else {
-                res.redirect(addLangToUrl(BASE_URL + DATE_OF_BIRTH, lang));
+                const redirectUrl = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+                    ? BASE_URL + CHECK_YOUR_ANSWERS
+                    : BASE_URL + DATE_OF_BIRTH;
+
+                res.redirect(addLangToUrl(redirectUrl, lang));
             }
         }).catch(error => {
             logger.error("Verification-Api error" + JSON.stringify(error));
@@ -63,9 +78,17 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 };
 
 const renderValidationError = (req: Request, res: Response, locales: LocalesService, lang: string, clientData: ClientData, pageProperties: any) => {
+
+    const session: Session = req.session as any as Session;
+    const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+
+    const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        : addLangToUrl(BASE_URL + PERSONAL_CODE, lang);
+
     res.status(400).render(config.PERSONS_EMAIL, {
         ...getLocaleInfo(locales, lang),
-        previousPage: addLangToUrl(BASE_URL + PERSONAL_CODE, lang),
+        previousPage: previousPage,
         currentUrl: BASE_URL + EMAIL_ADDRESS,
         payload: req.body,
         firstName: clientData?.firstName,

--- a/src/controllers/personsNameController.ts
+++ b/src/controllers/personsNameController.ts
@@ -24,8 +24,12 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     const previousPageUrl = getPreviousPageUrl(req, BASE_URL);
     saveDataInSession(req, PREVIOUS_PAGE_URL, previousPageUrl);
 
+    const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        : addLangToUrl(BASE_URL, lang);
+
     res.render(config.PERSONS_NAME, {
-        previousPage: addLangToUrl(BASE_URL, lang),
+        previousPage: previousPage,
         ...getLocaleInfo(locales, lang),
         matomoButtonClick: MATOMO_BUTTON_CLICK,
         currentUrl: BASE_URL + PERSONS_NAME,
@@ -39,9 +43,16 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
     const errorList = validationResult(req);
     if (!errorList.isEmpty()) {
         const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
+        const session: Session = req.session as any as Session;
+        const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+
+        const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+            ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+            : addLangToUrl(BASE_URL, lang);
+
         res.status(400).render(config.PERSONS_NAME, {
             ...getLocaleInfo(locales, lang),
-            previousPage: addLangToUrl(BASE_URL, lang),
+            previousPage: previousPage,
             currentUrl: BASE_URL + PERSONS_NAME,
             payload: req.body,
             ...pageProperties
@@ -56,10 +67,9 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
 
         saveDataInSession(req, USER_DATA, clientData);
 
-        const previousPageUrl : string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
-        console.log("abc------>", previousPageUrl );
+        const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
 
-        if (previousPageUrl === "/tell-companies-house-you-have-verified-someones-identity/check-your-answers?lang=en") {
+        if (previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)) {
             res.redirect(addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang));
         } else {
             res.redirect(addLangToUrl(BASE_URL + PERSONAL_CODE, lang));

--- a/src/controllers/personsNameController.ts
+++ b/src/controllers/personsNameController.ts
@@ -57,7 +57,7 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
         saveDataInSession(req, USER_DATA, clientData);
 
         const previousPageUrl : string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
-        console.log("abc------>", previousPageUrl);
+        console.log("abc------>", previousPageUrl );
 
         if (previousPageUrl === "/tell-companies-house-you-have-verified-someones-identity/check-your-answers?lang=en") {
             res.redirect(addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang));

--- a/src/controllers/whenIdentityChecksCompletedController.ts
+++ b/src/controllers/whenIdentityChecksCompletedController.ts
@@ -2,12 +2,13 @@ import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../validations/validation";
-import { BASE_URL, CONFIRM_HOME_ADDRESS, WHEN_IDENTITY_CHECKS_COMPLETED, HOW_IDENTITY_DOCUMENTS_CHECKED } from "../types/pageURL";
+import { BASE_URL, CONFIRM_HOME_ADDRESS, WHEN_IDENTITY_CHECKS_COMPLETED, HOW_IDENTITY_DOCUMENTS_CHECKED, CHECK_YOUR_ANSWERS } from "../types/pageURL";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
-import { USER_DATA, MATOMO_BUTTON_CLICK } from "../utils/constants";
+import { USER_DATA, MATOMO_BUTTON_CLICK, PREVIOUS_PAGE_URL } from "../utils/constants";
 import { ClientData } from "model/ClientData";
 import { saveDataInSession } from "../utils/sessionHelper";
+import { getPreviousPageUrl } from "../services/url";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
@@ -24,9 +25,17 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             "wicc-day": whenIdentityChecksCompleted.getDate()
         };
     }
+
+    const previousPageUrl = getPreviousPageUrl(req, BASE_URL);
+    saveDataInSession(req, PREVIOUS_PAGE_URL, previousPageUrl);
+
+    const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        : addLangToUrl(BASE_URL + CONFIRM_HOME_ADDRESS, lang);
+
     res.render(config.WHEN_IDENTITY_CHECKS_COMPLETED, {
         ...getLocaleInfo(locales, lang),
-        previousPage: addLangToUrl(BASE_URL + CONFIRM_HOME_ADDRESS, lang),
+        previousPage: previousPage,
         currentUrl: BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED,
         matomoButtonClick: MATOMO_BUTTON_CLICK,
         firstName: clientData?.firstName,
@@ -39,6 +48,11 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
     const session: Session = req.session as any as Session;
+    const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+
+    const previousPage = previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        ? addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)
+        : addLangToUrl(BASE_URL + CONFIRM_HOME_ADDRESS, lang);
 
     const clientData: ClientData = session?.getExtraData(USER_DATA)!;
     const errorList = validationResult(req);
@@ -46,7 +60,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
         res.status(400).render(config.WHEN_IDENTITY_CHECKS_COMPLETED, {
             ...getLocaleInfo(locales, lang),
-            previousPage: addLangToUrl(BASE_URL + CONFIRM_HOME_ADDRESS, lang),
+            previousPage: previousPage,
             currentUrl: BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED,
             pageProperties: pageProperties,
             payload: req.body,
@@ -63,6 +77,13 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             clientData.whenIdentityChecksCompleted = whenIdentityChecksCompleted;
         }
         saveDataInSession(req, USER_DATA, clientData);
-        res.redirect(addLangToUrl(BASE_URL + HOW_IDENTITY_DOCUMENTS_CHECKED, lang));
+
+        const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
+
+        if (previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)) {
+            res.redirect(addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang));
+        } else {
+            res.redirect(addLangToUrl(BASE_URL + HOW_IDENTITY_DOCUMENTS_CHECKED, lang));
+        }
     }
 };

--- a/src/controllers/whenIdentityChecksCompletedController.ts
+++ b/src/controllers/whenIdentityChecksCompletedController.ts
@@ -78,8 +78,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         }
         saveDataInSession(req, USER_DATA, clientData);
 
-        const previousPageUrl: string = session?.getExtraData(PREVIOUS_PAGE_URL)!;
-
         if (previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)) {
             res.redirect(addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang));
         } else {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,6 +2,7 @@ export const USER_DATA = "user";
 export const ADDRESS_LIST = "addressList";
 export const PREVIOUS_PAGE_URL: string = "previouspageurl";
 export const REFERENCE = "reference";
+export const CHECK_YOUR_ANSWERS_FLAG = "checkYourAnswersFlag";
 
 // Matomo
 export const MATOMO_BUTTON_CLICK = "Click button";

--- a/test/src/controllers/dateOfBirthController.test.ts
+++ b/test/src/controllers/dateOfBirthController.test.ts
@@ -53,7 +53,7 @@ describe("POST" + DATE_OF_BIRTH, () => {
             "dob-month": undefined,
             "dob-year": ""
         };
-        const res = await router.post(BASE_URL + DATE_OF_BIRTH).send(sendData);;
+        const res = await router.post(BASE_URL + DATE_OF_BIRTH).send(sendData);
         expect(res.status).toBe(400);
         expect(res.text).toContain("Enter your date of birth");
     });

--- a/test/src/controllers/dateOfBirthController.test.ts
+++ b/test/src/controllers/dateOfBirthController.test.ts
@@ -1,9 +1,15 @@
 import mocks from "../../mocks/all_middleware_mock";
 import supertest from "supertest";
 import app from "../../../src/app";
-import { BASE_URL, DATE_OF_BIRTH, HOME_ADDRESS } from "../../../src/types/pageURL";
+import { BASE_URL, CHECK_YOUR_ANSWERS, DATE_OF_BIRTH, HOME_ADDRESS } from "../../../src/types/pageURL";
+import { sessionMiddleware } from "../../../src/middleware/session_middleware";
+import { getSessionRequestWithPermission } from "../../mocks/session.mock";
+import { PREVIOUS_PAGE_URL } from "../../../src/utils/constants";
+import { Request, NextFunction } from "express";
 
 const router = supertest(app);
+
+let customMockSessionMiddleware: any;
 
 describe("GET" + DATE_OF_BIRTH, () => {
     it("should return status 200", async () => {
@@ -28,6 +34,18 @@ describe("POST" + DATE_OF_BIRTH, () => {
         expect(res.header.location).toBe(BASE_URL + HOME_ADDRESS + "?lang=en");
     });
 
+    it("should return status 302 after redirect to Check Your Answers", async () => {
+        createMockSessionMiddleware();
+        const sendData = {
+            "dob-day": "11",
+            "dob-month": "2",
+            "dob-year": "1999"
+        };
+        const res = await router.post(BASE_URL + DATE_OF_BIRTH).send(sendData);
+        expect(res.status).toBe(302);
+        expect(res.header.location).toBe(BASE_URL + CHECK_YOUR_ANSWERS + "?lang=en");
+    });
+
     // Test for incorrect form details entered, will return 400.
     it("should return status 400", async () => {
         const sendData = {
@@ -35,8 +53,18 @@ describe("POST" + DATE_OF_BIRTH, () => {
             "dob-month": undefined,
             "dob-year": ""
         };
-        const res = await router.post(BASE_URL + DATE_OF_BIRTH).send(sendData); ;
+        const res = await router.post(BASE_URL + DATE_OF_BIRTH).send(sendData);;
         expect(res.status).toBe(400);
         expect(res.text).toContain("Enter your date of birth");
     });
 });
+
+function createMockSessionMiddleware () {
+    customMockSessionMiddleware = sessionMiddleware as jest.Mock;
+    const session = getSessionRequestWithPermission();
+    session.setExtraData(PREVIOUS_PAGE_URL, "/tell-companies-house-you-have-verified-someones-identity/check-your-answers?lang=en");
+    customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.session = session;
+        next();
+    });
+}

--- a/test/src/controllers/identityDocumentsCheckedGroup1Controller.test.ts
+++ b/test/src/controllers/identityDocumentsCheckedGroup1Controller.test.ts
@@ -1,10 +1,16 @@
 import mocks from "../../mocks/all_middleware_mock";
 import supertest from "supertest";
 import app from "../../../src/app";
-import { BASE_URL, CONFIRM_IDENTITY_VERIFICATION, WHICH_IDENTITY_DOCS_CHECKED_GROUP1 } from "../../../src/types/pageURL";
+import { BASE_URL, CHECK_YOUR_ANSWERS, CONFIRM_IDENTITY_VERIFICATION, WHICH_IDENTITY_DOCS_CHECKED_GROUP1 } from "../../../src/types/pageURL";
+import { sessionMiddleware } from "../../../src/middleware/session_middleware";
+import { getSessionRequestWithPermission } from "../../mocks/session.mock";
+import { CHECK_YOUR_ANSWERS_FLAG, USER_DATA } from "../../../src/utils/constants";
+import { Request, Response, NextFunction } from "express";
 jest.mock("@companieshouse/api-sdk-node");
 
 const router = supertest(app);
+
+let customMockSessionMiddleware: any;
 
 describe("GET" + WHICH_IDENTITY_DOCS_CHECKED_GROUP1, () => {
     it("should return status 200", async () => {
@@ -28,6 +34,16 @@ describe("POST" + WHICH_IDENTITY_DOCS_CHECKED_GROUP1, () => {
         expect(res.header.location).toBe(BASE_URL + CONFIRM_IDENTITY_VERIFICATION + "?lang=en");
     });
 
+    it("should return status 302 after redirecting to Check Your Answers", async () => {
+        createMockSessionMiddleware();
+        const inputData = {
+            documentsGroup1: ["biometricPassport", "ukDriversLicence"]
+        };
+        const res = await router.post(BASE_URL + WHICH_IDENTITY_DOCS_CHECKED_GROUP1).send(inputData);
+        expect(res.status).toBe(302);
+        expect(res.header.location).toBe(BASE_URL + CHECK_YOUR_ANSWERS + "?lang=en");
+    });
+
     it("should return status 400 when no documents are selected", async () => {
         const inputData = {};
         const res = await router.post(BASE_URL + WHICH_IDENTITY_DOCS_CHECKED_GROUP1).send(inputData);
@@ -35,3 +51,16 @@ describe("POST" + WHICH_IDENTITY_DOCS_CHECKED_GROUP1, () => {
         expect(res.text).toContain("Select which documents you checked to verify their identity");
     });
 });
+
+function createMockSessionMiddleware () {
+    customMockSessionMiddleware = sessionMiddleware as jest.Mock;
+    const session = getSessionRequestWithPermission();
+    session.setExtraData(CHECK_YOUR_ANSWERS_FLAG, true);
+    session.setExtraData(USER_DATA, {
+        howIdentityDocsChecked: "cryptographic_security_features_checked"
+    });
+    customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.session = session;
+        next();
+    });
+}

--- a/test/src/controllers/identityDocumentsCheckedGroup2Controller.test.ts
+++ b/test/src/controllers/identityDocumentsCheckedGroup2Controller.test.ts
@@ -1,10 +1,16 @@
 import mocks from "../../mocks/all_middleware_mock";
 import supertest from "supertest";
 import app from "../../../src/app";
-import { BASE_URL, CONFIRM_IDENTITY_VERIFICATION, WHICH_IDENTITY_DOCS_CHECKED_GROUP2 } from "../../../src/types/pageURL";
+import { BASE_URL, CHECK_YOUR_ANSWERS, CONFIRM_IDENTITY_VERIFICATION, WHICH_IDENTITY_DOCS_CHECKED_GROUP2 } from "../../../src/types/pageURL";
+import { sessionMiddleware } from "../../../src/middleware/session_middleware";
+import { getSessionRequestWithPermission } from "../../mocks/session.mock";
+import { CHECK_YOUR_ANSWERS_FLAG, USER_DATA } from "../../../src/utils/constants";
+import { Request, Response, NextFunction } from "express";
 jest.mock("@companieshouse/api-sdk-node");
 
 const router = supertest(app);
+
+let customMockSessionMiddleware: any;
 
 describe("GET" + WHICH_IDENTITY_DOCS_CHECKED_GROUP2, () => {
     it("should return status 200", async () => {
@@ -29,6 +35,17 @@ describe("POST" + WHICH_IDENTITY_DOCS_CHECKED_GROUP2, () => {
         expect(res.header.location).toBe(BASE_URL + CONFIRM_IDENTITY_VERIFICATION + "?lang=en");
     });
 
+    it("should return status 302 after redirecting to Check Your Answers", async () => {
+        createMockSessionMiddleware();
+        const inputData = {
+            documentsGroup2A: ["ukFrontierPermit"],
+            documentsGroup2B: ["marriageCert"]
+        };
+        const res = await router.post(BASE_URL + WHICH_IDENTITY_DOCS_CHECKED_GROUP2).send(inputData);
+        expect(res.status).toBe(302);
+        expect(res.header.location).toBe(BASE_URL + CHECK_YOUR_ANSWERS + "?lang=en");
+    });
+
     it("should return status 400 when no documents are selected", async () => {
         const inputData = {};
         const res = await router.post(BASE_URL + WHICH_IDENTITY_DOCS_CHECKED_GROUP2).send(inputData);
@@ -37,3 +54,16 @@ describe("POST" + WHICH_IDENTITY_DOCS_CHECKED_GROUP2, () => {
     });
 
 });
+
+function createMockSessionMiddleware () {
+    customMockSessionMiddleware = sessionMiddleware as jest.Mock;
+    const session = getSessionRequestWithPermission();
+    session.setExtraData(CHECK_YOUR_ANSWERS_FLAG, true);
+    session.setExtraData(USER_DATA, {
+        howIdentityDocsChecked: "cryptographic_security_features_checked"
+    });
+    customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.session = session;
+        next();
+    });
+}

--- a/test/src/controllers/personsNameController.test.ts
+++ b/test/src/controllers/personsNameController.test.ts
@@ -1,9 +1,16 @@
 import mocks from "../../mocks/all_middleware_mock";
 import supertest from "supertest";
 import app from "../../../src/app";
-import { BASE_URL, PERSONS_NAME, PERSONAL_CODE } from "../../../src/types/pageURL";
+import { BASE_URL, PERSONS_NAME, PERSONAL_CODE, CHECK_YOUR_ANSWERS } from "../../../src/types/pageURL";
+import { PREVIOUS_PAGE_URL } from "../../../src/utils/constants";
+import { sessionMiddleware } from "../../../src/middleware/session_middleware";
+import { getSessionRequestWithPermission } from "../../mocks/session.mock";
+import { Request, Response, NextFunction } from "express";
+import { session } from "../../mocks/session_middleware_mock";
 
 const router = supertest(app);
+
+let customMockSessionMiddleware: any;
 
 describe("GET" + PERSONS_NAME, () => {
     it("should return status 200", async () => {
@@ -17,6 +24,7 @@ describe("GET" + PERSONS_NAME, () => {
 describe("POST" + PERSONS_NAME, () => {
     // Test for correct form details entered, will return 302 after redirecting to the next page.
     it("should return status 302 after redirect", async () => {
+        session.setExtraData(PREVIOUS_PAGE_URL, "/tell-companies-house-you-have-verified-someones-identity?lang=en");
         const res = await router.post(BASE_URL + PERSONS_NAME)
             .send({
                 "first-name": "John",
@@ -29,6 +37,19 @@ describe("POST" + PERSONS_NAME, () => {
         expect(res.header.location).toBe(BASE_URL + PERSONAL_CODE + "?lang=en");
     });
 
+    it("should return status 302 after redirect to Check Your Answers", async () => {
+        createMockSessionMiddleware();
+        const res = await router.post(BASE_URL + PERSONS_NAME)
+            .send({
+                "first-name": "John",
+                "middle-names": "",
+                "last-name": "Doe"
+            });
+        expect(res.status).toBe(302);
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+        expect(res.header.location).toBe(BASE_URL + CHECK_YOUR_ANSWERS + "?lang=en");
+    });
+
     // Test for incorrect form details entered, will return 400.
     it("should return status 400 after incorrect data entered", async () => {
         const sendData = {
@@ -36,7 +57,7 @@ describe("POST" + PERSONS_NAME, () => {
             "middle-names": "middlename",
             "last-name": "lname"
         };
-        const res = await router.post(BASE_URL + PERSONS_NAME).send(sendData); ;
+        const res = await router.post(BASE_URL + PERSONS_NAME).send(sendData);;
         expect(res.status).toBe(400);
         expect(res.text).toContain("Enter your first name");
     });
@@ -46,8 +67,18 @@ describe("POST" + PERSONS_NAME, () => {
             "middle-names": "",
             "last-name": ""
         };
-        const res = await router.post(BASE_URL + PERSONS_NAME).send(sendData); ;
+        const res = await router.post(BASE_URL + PERSONS_NAME).send(sendData);;
         expect(res.status).toBe(400);
         expect(res.text).toContain("Enter your last name");
     });
 });
+
+function createMockSessionMiddleware () {
+    customMockSessionMiddleware = sessionMiddleware as jest.Mock;
+    const session = getSessionRequestWithPermission();
+    session.setExtraData(PREVIOUS_PAGE_URL, "/tell-companies-house-you-have-verified-someones-identity/check-your-answers?lang=en");
+    customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.session = session;
+        next();
+    });
+}

--- a/test/src/controllers/personsNameController.test.ts
+++ b/test/src/controllers/personsNameController.test.ts
@@ -57,7 +57,7 @@ describe("POST" + PERSONS_NAME, () => {
             "middle-names": "middlename",
             "last-name": "lname"
         };
-        const res = await router.post(BASE_URL + PERSONS_NAME).send(sendData);;
+        const res = await router.post(BASE_URL + PERSONS_NAME).send(sendData);
         expect(res.status).toBe(400);
         expect(res.text).toContain("Enter your first name");
     });
@@ -67,7 +67,7 @@ describe("POST" + PERSONS_NAME, () => {
             "middle-names": "",
             "last-name": ""
         };
-        const res = await router.post(BASE_URL + PERSONS_NAME).send(sendData);;
+        const res = await router.post(BASE_URL + PERSONS_NAME).send(sendData);
         expect(res.status).toBe(400);
         expect(res.text).toContain("Enter your last name");
     });

--- a/test/src/controllers/whenIdentityChecksCompletedController.test.ts
+++ b/test/src/controllers/whenIdentityChecksCompletedController.test.ts
@@ -1,9 +1,15 @@
 import mocks from "../../mocks/all_middleware_mock";
 import supertest from "supertest";
 import app from "../../../src/app";
-import { BASE_URL, WHEN_IDENTITY_CHECKS_COMPLETED, HOW_IDENTITY_DOCUMENTS_CHECKED } from "../../../src/types/pageURL";
+import { BASE_URL, WHEN_IDENTITY_CHECKS_COMPLETED, HOW_IDENTITY_DOCUMENTS_CHECKED, CHECK_YOUR_ANSWERS } from "../../../src/types/pageURL";
+import { sessionMiddleware } from "../../../src/middleware/session_middleware";
+import { getSessionRequestWithPermission } from "../../mocks/session.mock";
+import { PREVIOUS_PAGE_URL } from "../../../src/utils/constants";
+import { Request, Response, NextFunction } from "express";
 
 const router = supertest(app);
+
+let customMockSessionMiddleware: any;
 
 describe("GET" + WHEN_IDENTITY_CHECKS_COMPLETED, () => {
     it("should return status 200", async () => {
@@ -28,6 +34,18 @@ describe("POST" + WHEN_IDENTITY_CHECKS_COMPLETED, () => {
         expect(res.header.location).toBe(BASE_URL + HOW_IDENTITY_DOCUMENTS_CHECKED + "?lang=en");
     });
 
+    it("should return status 302 after redirect to Check Your Answers", async () => {
+        createMockSessionMiddleware();
+        const sendData = {
+            "wicc-day": "08",
+            "wicc-month": "07",
+            "wicc-year": "2024"
+        };
+        const res = await router.post(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED).send(sendData);
+        expect(res.status).toBe(302);
+        expect(res.header.location).toBe(BASE_URL + CHECK_YOUR_ANSWERS + "?lang=en");
+    });
+
     // Test for incorrect form details entered, will return 400.
     it("should return status 400", async () => {
         const sendData = {
@@ -35,8 +53,18 @@ describe("POST" + WHEN_IDENTITY_CHECKS_COMPLETED, () => {
             "wicc-month": undefined,
             "wicc-year": ""
         };
-        const res = await router.post(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED).send(sendData); ;
+        const res = await router.post(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED).send(sendData);;
         expect(res.status).toBe(400);
         expect(res.text).toContain("When were the identity checks completed?");
     });
 });
+
+function createMockSessionMiddleware () {
+    customMockSessionMiddleware = sessionMiddleware as jest.Mock;
+    const session = getSessionRequestWithPermission();
+    session.setExtraData(PREVIOUS_PAGE_URL, "/tell-companies-house-you-have-verified-someones-identity/check-your-answers?lang=en");
+    customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.session = session;
+        next();
+    });
+}

--- a/test/src/controllers/whenIdentityChecksCompletedController.test.ts
+++ b/test/src/controllers/whenIdentityChecksCompletedController.test.ts
@@ -53,7 +53,7 @@ describe("POST" + WHEN_IDENTITY_CHECKS_COMPLETED, () => {
             "wicc-month": undefined,
             "wicc-year": ""
         };
-        const res = await router.post(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED).send(sendData);;
+        const res = await router.post(BASE_URL + WHEN_IDENTITY_CHECKS_COMPLETED).send(sendData);
         expect(res.status).toBe(400);
         expect(res.text).toContain("When were the identity checks completed?");
     });


### PR DESCRIPTION
**Short description outlining key changes/additions**

- Reuse function getPreviousPageUrl and store in session variable in GET request on pages
- In POST request, logic added to check if this previousPageUrl was CYA then redirect to CYA otherwise redirect to next screen in the flow with 2 exceptions as follows:
- address screens have 3 in the sequence so only the confirmation screen will send back to CYA (reviewed behaviour with PO) using a flag set to true when user reaches CYA 'checkYourAnswersFlag' and check this when reaching the address confirmation
- identity check option 1/2 screens have conditional logic so the identityDocumentsChecked screens will send back to CYA. Also using 'checkYourAnswersFlag' to go back once on final documents screens.
- if a user goes back and changes between option 1+2 then the list of documents is getting cleared allowing the user to select the documents from the new list
- Back button logic added so that user can either click back button or continue to go back to CYA after changing a value 

**JIRA Ticket Number**

[IDVA5-1313](https://companieshouse.atlassian.net/browse/IDVA5-1313)

**Type of change**
 
- [ ] Bug fix
- [X]  New feature
- [ ]  Breaking change
- [ ]  Infrastructure change

**Pull request checklist**

- [X]  I have added unit tests for new code that I have added
- [ ]  I have added/updated functional tests where appropriate
- [X]  The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

**An exhaustive list of peer review checks can be read** [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)

[IDVA5-1313]: https://companieshouse.atlassian.net/browse/IDVA5-1313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ