### PR TITLE
IDVA5-1482 New links to clear session when verifying another client

### DIFF
--- a/locales/cy/confirmation.json
+++ b/locales/cy/confirmation.json
@@ -25,5 +25,9 @@
   "printFromBrowser": "I argraffu'r dudalen hon, dewiswch print o'ch dewislen porwr.",
   "whatToDoNext": "What do you want to do next? welsh",
   "linkToVerifyService": "Tell Companies House about another identity you have verified welsh",
-  "linkAuthorisedAgentAccount": "View authorised agent account welsh"
+  "linkAuthorisedAgentAccount": "View authorised agent account welsh",
+  "feedbackSurveyTitle": "Feedback welsh",
+  "feedbackSurveyLine1": "This is a new service. welsh",
+  "feedbackSurveyLink": "Complete our quick survey (opens in a new tab) welsh",
+  "feedbackSurveyLine2": "to help us improve it. welsh"
 } 

--- a/locales/cy/confirmation.json
+++ b/locales/cy/confirmation.json
@@ -22,5 +22,8 @@
   "option1Confirmation": "Opsiwn 1 - Gwiriwyd y dogfennau gan ddefnyddio technoleg dilysu dogfennau adnabod (IDVT).",
   "option2Confirmation": "Opsiwn 2 - cafodd y dogfennau eu gwirio gan berson",
   "printButton": "Argraffu y dudalen hon",
-  "printFromBrowser": "I argraffu'r dudalen hon, dewiswch print o'ch dewislen porwr."
+  "printFromBrowser": "I argraffu'r dudalen hon, dewiswch print o'ch dewislen porwr.",
+  "whatToDoNext": "What do you want to do next? welsh",
+  "linkToVerifyService": "Tell Companies House about another identity you have verified welsh",
+  "linkAuthorisedAgentAccount": "View authorised agent account welsh"
 } 

--- a/locales/cy/error-pages.json
+++ b/locales/cy/error-pages.json
@@ -1,5 +1,5 @@
 {
-    "pageNotFoundTitle": "Tudalen heb ei darganfod",
+    "pageNotFoundTitle": "Ni chafwyd hyd i'r dudalen",
     "pageNotFoundText1": "Os gwnaethoch deipio'r cyfeiriad gwe, gwiriwch ei fod wedi'i sillafu'n gywir.",
     "pageNotFoundText2": "Os gwnaethoch chi gludo'r cyfeiriad gwe, gwiriwch eich bod wedi copïo'r cyfeiriad cyfan.",
     "pageNotFoundText3": "Os yw'r cyfeiriad gwe yn gywir neu os ydych wedi dewis dolen, efallai bod y dudalen wedi symud. Ewch i'r ",

--- a/locales/cy/personal-code.json
+++ b/locales/cy/personal-code.json
@@ -2,7 +2,7 @@
     "codePageTitle": "Cod personol Tŷ'r Cwmnïau",
     "codePageHeading": "Cod personol Tŷ'r Cwmnïau",
     "onceYou": "Unwaith y byddwch wedi gwirio hunaniaeth ",
-    "identity": ", sbyddwn yn anfon ei god personol Tŷ'r Cwmnïau i'r cyfeiriad e-bost rydych yn ei ddarparu ar y dudalen nesaf. Bydd angen iddynt ddefnyddio hyn i gysylltu ei hunaniaeth wedi'i gwirio â'n cofnodion.",
+    "identity": ", byddwn yn anfon ei god personol Tŷ'r Cwmnïau i'r cyfeiriad e-bost rydych yn ei ddarparu ar y dudalen nesaf. Bydd angen iddynt ddefnyddio hyn i gysylltu ei hunaniaeth wedi'i gwirio â'n cofnodion.",
     "weWill": "Byddwn yn rhoi gwybod iddynt y gallant rannu'r cod personol gyda phobl y maent yn ymddiried ynddynt i ffeilio ar ei rhan.",
     "whenThey": "Pan fydd angen ei god personol arnynt",
     "theyMay": "Efallai y bydd angen iddynt ddarparu ei god personol am amryw resymau, gan gynnwys:",

--- a/locales/en/confirmation.json
+++ b/locales/en/confirmation.json
@@ -25,5 +25,9 @@
   "printFromBrowser": "To print this page, select print from your browser menu.",
   "whatToDoNext": "What do you want to do next?",
   "linkToVerifyService": "Tell Companies House about another identity you have verified",
-  "linkAuthorisedAgentAccount": "View authorised agent account"
+  "linkAuthorisedAgentAccount": "View authorised agent account",
+  "feedbackSurveyTitle": "Feedback",
+  "feedbackSurveyLine1": "This is a new service.",
+  "feedbackSurveyLink": "Complete our quick survey (opens in a new tab)",
+  "feedbackSurveyLine2": "to help us improve it."
 }

--- a/locales/en/confirmation.json
+++ b/locales/en/confirmation.json
@@ -22,5 +22,8 @@
   "option1Confirmation": "Option 1 - The documents were checked using identity document validation technology (IDVT).",
   "option2Confirmation": "Option 2 - The documents were checked by a person.",
   "printButton": "Print this page",
-  "printFromBrowser": "To print this page, select print from your browser menu."
+  "printFromBrowser": "To print this page, select print from your browser menu.",
+  "whatToDoNext": "What do you want to do next?",
+  "linkToVerifyService": "Tell Companies House about another identity you have verified",
+  "linkAuthorisedAgentAccount": "View authorised agent account"
 }

--- a/src/controllers/confirmationController.ts
+++ b/src/controllers/confirmationController.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
 import { FormatService } from "../services/formatService";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
-import { CHECK_YOUR_ANSWERS, BASE_URL, CONFIRMATION } from "../types/pageURL";
+import { CHECK_YOUR_ANSWERS, BASE_URL, CONFIRMATION, CONFIRMATION_REDIRECT } from "../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { ACSP_DETAILS, REFERENCE, USER_DATA } from "../utils/constants";
 import { ClientData } from "../model/ClientData";
@@ -39,6 +39,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         reference,
         amlBodies,
         acspName: acspDetails.name,
+        verifyServiceLink: addLangToUrl(BASE_URL + CONFIRMATION_REDIRECT + "?id=verify-service-link", lang),
+        authorisedAgentLink: addLangToUrl(BASE_URL + CONFIRMATION_REDIRECT + "?id=authorised-agent-account-link", lang),
         clientData: {
             ...clientData,
             address: formattedAddress,

--- a/src/controllers/confirmationRedirectController.ts
+++ b/src/controllers/confirmationRedirectController.ts
@@ -1,0 +1,27 @@
+import { NextFunction, Request, Response } from "express";
+import { Session } from "@companieshouse/node-session-handler";
+import { CHECK_YOUR_ANSWERS_FLAG, USER_DATA } from "../utils/constants";
+import { addLangToUrl, selectLang } from "../utils/localise";
+import { BASE_URL, PERSONS_NAME } from "../types/pageURL";
+
+export const get = (req: Request, res: Response, next: NextFunction) => {
+    const session = req.session as Session;
+    const lang = selectLang(req.query.lang);
+
+    // Clear session data + CYA flag
+    session.deleteExtraData(USER_DATA);
+    session.deleteExtraData(CHECK_YOUR_ANSWERS_FLAG);
+
+    const id = req.query.id as string;
+    let redirectUrl = "";
+
+    if (id === "verify-service-link") {
+        redirectUrl = BASE_URL;
+    } else if (id === "authorised-agent-account-link") {
+        // authorised agent link placeholder - need to update later
+        redirectUrl = "#";
+    }
+
+    // Redirect to the desired URL
+    return res.redirect(addLangToUrl(redirectUrl, lang));
+};

--- a/src/controllers/confirmationRedirectController.ts
+++ b/src/controllers/confirmationRedirectController.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { Session } from "@companieshouse/node-session-handler";
 import { CHECK_YOUR_ANSWERS_FLAG, USER_DATA } from "../utils/constants";
 import { addLangToUrl, selectLang } from "../utils/localise";
-import { BASE_URL, PERSONS_NAME } from "../types/pageURL";
+import { BASE_URL } from "../types/pageURL";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
     const session = req.session as Session;

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -18,3 +18,4 @@ export * as checkYourAnswersController from "./checkYourAnswers";
 export * as confirmationController from "./confirmationController";
 export * as confirmIdentityVerificationController from "./confirmIdentityVerificationController";
 export * as signOutController from "./signOutController";
+export * as confirmationRedirectController from "./confirmationRedirectController";

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -19,7 +19,8 @@ import {
     confirmIdentityVerificationController,
     signOutController,
     confirmationController,
-    provideDifferentEmailController
+    provideDifferentEmailController,
+    confirmationRedirectController
 } from "../controllers";
 
 import * as urls from "../types/pageURL";
@@ -92,5 +93,7 @@ routes.post(urls.SIGN_OUT_URL, selectsignOutValidator, signOutController.post);
 routes.get(urls.CONFIRMATION, confirmationController.get);
 routes.get(urls.CHECK_YOUR_ANSWERS, checkYourAnswersController.get);
 routes.post(urls.CHECK_YOUR_ANSWERS, checkYourAnswerValidator, checkYourAnswersController.post);
+
+routes.get(urls.CONFIRMATION_REDIRECT, confirmationRedirectController.get);
 
 export default routes;

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -47,3 +47,5 @@ export const WHICH_IDENTITY_DOCS_CHECKED_GROUP2 = "/identity-documents-checked-g
 export const CHECK_YOUR_ANSWERS = "/check-your-answers";
 
 export const CONFIRMATION = "/confirmation";
+
+export const CONFIRMATION_REDIRECT = "/confirmation-redirect";

--- a/src/views/confirmation/confirmation.njk
+++ b/src/views/confirmation/confirmation.njk
@@ -39,6 +39,7 @@
   {% set howIdentityDocsChecked = i18n.option2Confirmation %}
 {% endif %}
 
+<form action="" id="confirmationForm" method="POST">
   {{ govukSummaryList({
     rows: [
       {
@@ -107,4 +108,14 @@
       }
     ]
   }) }}
+
+  <h2 class="govuk-heading-m">{{ i18n.whatToDoNext }}</h2>
+  <p class="govuk-body">
+    <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=verify-service-link" class="govuk-link" id="verify-service-link"">{{ i18n.linkToVerifyService }}</a>
+  </p>
+  <p class="govuk-body">
+    <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=authorised-agent-account-link" class="govuk-link" id="authorised-agent-account-link">{{ i18n.linkAuthorisedAgentAccount }}</a>
+  </p>
+</form>
+
 {% endblock %}

--- a/src/views/confirmation/confirmation.njk
+++ b/src/views/confirmation/confirmation.njk
@@ -110,7 +110,7 @@
 
   <h2 class="govuk-heading-m">{{ i18n.whatToDoNext }}</h2>
   <p class="govuk-body">
-    <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=verify-service-link" class="govuk-link" id="verify-service-link"">{{ i18n.linkToVerifyService }}</a>
+    <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=verify-service-link" class="govuk-link" id="verify-service-link">{{ i18n.linkToVerifyService }}</a>
   </p>
   <p class="govuk-body">
     <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=authorised-agent-account-link" class="govuk-link" id="authorised-agent-account-link">{{ i18n.linkAuthorisedAgentAccount }}</a>

--- a/src/views/confirmation/confirmation.njk
+++ b/src/views/confirmation/confirmation.njk
@@ -39,81 +39,81 @@
   {% set howIdentityDocsChecked = i18n.option2Confirmation %}
 {% endif %}
 
-{{ govukSummaryList({
-  rows: [
-    {
-      key: {
-        text: i18n.name
+  {{ govukSummaryList({
+    rows: [
+      {
+        key: {
+          text: i18n.name
+        },
+        value: {
+          text: fullName
+        }
       },
-      value: {
-        text: fullName
-      }
-    },
-    {
-      key: {
-        text: i18n.emailAddressConfirmation
+      {
+        key: {
+          text: i18n.emailAddressConfirmation
+        },
+        value: {
+          text: clientData.emailAddress
+        }
       },
-      value: {
-        text: clientData.emailAddress
-      }
-    },
-    {
-      key: {
-        text: i18n.dateOfBirth
+      {
+        key: {
+          text: i18n.dateOfBirth
+        },
+        value: {
+          text: clientData.dateOfBirth
+        }
       },
-      value: {
-        text: clientData.dateOfBirth
-      }
-    },
-    {
-      key: {
-        text: i18n.homeAdd
+      {
+        key: {
+          text: i18n.homeAdd
+        },
+        value: {
+          text: clientData.address | safe
+        }
       },
-      value: {
-        text: clientData.address | safe
-      }
-    },
-    {
-      key: {
-        text: i18n.dateIdentityCompleted
+      {
+        key: {
+          text: i18n.dateIdentityCompleted
+        },
+        value: {
+          text: clientData.whenIdentityChecksCompleted
+        }
       },
-      value: {
-        text: clientData.whenIdentityChecksCompleted
-      }
-    },
-    {
-      key: {
-        text: i18n.optionUsed
+      {
+        key: {
+          text: i18n.optionUsed
+        },
+        value: {
+          text: howIdentityDocsChecked
+        }
       },
-      value: {
-        text: howIdentityDocsChecked
-      }
-    },
-    {
-      key: {
-        text: i18n.identityDoc
+      {
+        key: {
+          text: i18n.identityDoc
+        },
+        value: {
+          text: clientData.documentsChecked | safe
+        }
       },
-      value: {
-        text: clientData.documentsChecked | safe
+      {
+        key: {
+          text: i18n.identityVerification
+        },
+        value: {
+          html: i18n.iConfirm + " " + acspName + " " + i18n.verifiedThe + " " + clientData.firstName + " " + clientData.lastName + " " + i18n.toTheStandard + "<br>" + acspName + " " + i18n.isSupervised + " " + amlBodies
+        }
       }
-    },
-    {
-      key: {
-        text: i18n.identityVerification
-      },
-      value: {
-        html: i18n.iConfirm + " " + acspName + " " + i18n.verifiedThe + " " + clientData.firstName + " " + clientData.lastName + " " + i18n.toTheStandard + "<br>" + acspName + " " + i18n.isSupervised + " " + amlBodies
-      }
-    }
-  ]
-}) }}
+    ]
+  }) }}
 
-<h2 class="govuk-heading-m">{{ i18n.whatToDoNext }}</h2>
-<p class="govuk-body">
-  <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=verify-service-link" class="govuk-link" id="verify-service-link"">{{ i18n.linkToVerifyService }}</a>
-</p>
-<p class="govuk-body">
-  <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=authorised-agent-account-link" class="govuk-link" id="authorised-agent-account-link">{{ i18n.linkAuthorisedAgentAccount }}</a>
-</p>
+  <h2 class="govuk-heading-m">{{ i18n.whatToDoNext }}</h2>
+  <p class="govuk-body">
+    <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=verify-service-link" class="govuk-link" id="verify-service-link"">{{ i18n.linkToVerifyService }}</a>
+  </p>
+  <p class="govuk-body">
+    <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=authorised-agent-account-link" class="govuk-link" id="authorised-agent-account-link">{{ i18n.linkAuthorisedAgentAccount }}</a>
+  </p>
 
 {% endblock %}

--- a/src/views/confirmation/confirmation.njk
+++ b/src/views/confirmation/confirmation.njk
@@ -110,10 +110,15 @@
 
   <h2 class="govuk-heading-m">{{ i18n.whatToDoNext }}</h2>
   <p class="govuk-body">
-    <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=verify-service-link" class="govuk-link" id="verify-service-link">{{ i18n.linkToVerifyService }}</a>
+    <a href={{verifyServiceLink}} class="govuk-link" id="verify-service-link">{{ i18n.linkToVerifyService }}</a>
   </p>
   <p class="govuk-body">
-    <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=authorised-agent-account-link" class="govuk-link" id="authorised-agent-account-link">{{ i18n.linkAuthorisedAgentAccount }}</a>
+    <a href={{authorisedAgentLink}} class="govuk-link" id="authorised-agent-account-link">{{ i18n.linkAuthorisedAgentAccount }}</a>
+  </p>
+
+  <h2 class="govuk-heading-m">{{ i18n.feedbackSurveyTitle }}</h2>
+  <p class="govuk-body">
+    {{ i18n.feedbackSurveyLine1 }} <a href="#" class="govuk-link" target="_blank">{{i18n.feedbackSurveyLink}}</a> {{ i18n.feedbackSurveyLine2 }}
   </p>
 
 {% endblock %}

--- a/src/views/confirmation/confirmation.njk
+++ b/src/views/confirmation/confirmation.njk
@@ -39,83 +39,81 @@
   {% set howIdentityDocsChecked = i18n.option2Confirmation %}
 {% endif %}
 
-<form action="" id="confirmationForm" method="POST">
-  {{ govukSummaryList({
-    rows: [
-      {
-        key: {
-          text: i18n.name
-        },
-        value: {
-          text: fullName
-        }
+{{ govukSummaryList({
+  rows: [
+    {
+      key: {
+        text: i18n.name
       },
-      {
-        key: {
-          text: i18n.emailAddressConfirmation
-        },
-        value: {
-          text: clientData.emailAddress
-        }
-      },
-      {
-        key: {
-          text: i18n.dateOfBirth
-        },
-        value: {
-          text: clientData.dateOfBirth
-        }
-      },
-      {
-        key: {
-          text: i18n.homeAdd
-        },
-        value: {
-          text: clientData.address | safe
-        }
-      },
-      {
-        key: {
-          text: i18n.dateIdentityCompleted
-        },
-        value: {
-          text: clientData.whenIdentityChecksCompleted
-        }
-      },
-      {
-        key: {
-          text: i18n.optionUsed
-        },
-        value: {
-          text: howIdentityDocsChecked
-        }
-      },
-      {
-        key: {
-          text: i18n.identityDoc
-        },
-        value: {
-          text: clientData.documentsChecked | safe
-        }
-      },
-      {
-        key: {
-          text: i18n.identityVerification
-        },
-        value: {
-          html: i18n.iConfirm + " " + acspName + " " + i18n.verifiedThe + " " + clientData.firstName + " " + clientData.lastName + " " + i18n.toTheStandard + "<br>" + acspName + " " + i18n.isSupervised + " " + amlBodies
-        }
+      value: {
+        text: fullName
       }
-    ]
-  }) }}
+    },
+    {
+      key: {
+        text: i18n.emailAddressConfirmation
+      },
+      value: {
+        text: clientData.emailAddress
+      }
+    },
+    {
+      key: {
+        text: i18n.dateOfBirth
+      },
+      value: {
+        text: clientData.dateOfBirth
+      }
+    },
+    {
+      key: {
+        text: i18n.homeAdd
+      },
+      value: {
+        text: clientData.address | safe
+      }
+    },
+    {
+      key: {
+        text: i18n.dateIdentityCompleted
+      },
+      value: {
+        text: clientData.whenIdentityChecksCompleted
+      }
+    },
+    {
+      key: {
+        text: i18n.optionUsed
+      },
+      value: {
+        text: howIdentityDocsChecked
+      }
+    },
+    {
+      key: {
+        text: i18n.identityDoc
+      },
+      value: {
+        text: clientData.documentsChecked | safe
+      }
+    },
+    {
+      key: {
+        text: i18n.identityVerification
+      },
+      value: {
+        html: i18n.iConfirm + " " + acspName + " " + i18n.verifiedThe + " " + clientData.firstName + " " + clientData.lastName + " " + i18n.toTheStandard + "<br>" + acspName + " " + i18n.isSupervised + " " + amlBodies
+      }
+    }
+  ]
+}) }}
 
-  <h2 class="govuk-heading-m">{{ i18n.whatToDoNext }}</h2>
-  <p class="govuk-body">
-    <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=verify-service-link" class="govuk-link" id="verify-service-link"">{{ i18n.linkToVerifyService }}</a>
-  </p>
-  <p class="govuk-body">
-    <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=authorised-agent-account-link" class="govuk-link" id="authorised-agent-account-link">{{ i18n.linkAuthorisedAgentAccount }}</a>
-  </p>
-</form>
+<h2 class="govuk-heading-m">{{ i18n.whatToDoNext }}</h2>
+<p class="govuk-body">
+  <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=verify-service-link" class="govuk-link" id="verify-service-link"">{{ i18n.linkToVerifyService }}</a>
+</p>
+<p class="govuk-body">
+  <a href="/tell-companies-house-you-have-verified-someones-identity/confirmation-redirect?id=authorised-agent-account-link" class="govuk-link" id="authorised-agent-account-link">{{ i18n.linkAuthorisedAgentAccount }}</a>
+</p>
 
 {% endblock %}

--- a/test/src/controllers/confirmationRedirectController.test.ts
+++ b/test/src/controllers/confirmationRedirectController.test.ts
@@ -1,0 +1,48 @@
+import mocks from "../../mocks/all_middleware_mock";
+import supertest from "supertest";
+import app from "../../../src/app";
+import { BASE_URL, CONFIRMATION_REDIRECT } from "../../../src/types/pageURL";
+import { createRequest, Session } from "node-mocks-http";
+import { getSessionRequestWithPermission } from "../../mocks/session.mock";
+import { CHECK_YOUR_ANSWERS_FLAG, USER_DATA } from "../../../src/utils/constants";
+import { session } from "../../mocks/session_middleware_mock";
+
+const router = supertest(app);
+
+describe("GET " + CONFIRMATION_REDIRECT, () => {
+    let req;
+    beforeEach(() => {
+        jest.clearAllMocks();
+        req = createRequest({
+            method: "GET",
+            url: "/"
+        });
+        const session = getSessionRequestWithPermission();
+        req.session = session;
+    });
+
+    it("should redirect to BASE_URL and clear session data when id is verify-service-link", async () => {
+
+        const res = await router
+            .get(BASE_URL + CONFIRMATION_REDIRECT)
+            .query({ id: "verify-service-link" });
+
+        expect(res.status).toBe(302);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(res.header.location).toBe(BASE_URL + "?lang=en");
+        expect(session.getExtraData(USER_DATA)).toBeUndefined();
+        expect(session.getExtraData(CHECK_YOUR_ANSWERS_FLAG)).toBeUndefined();
+    });
+
+    it("should redirect to Authorised Agent Account link and clear session data when id is authorised-agent-account-link", async () => {
+        const res = await router
+            .get(BASE_URL + CONFIRMATION_REDIRECT)
+            .query({ id: "authorised-agent-account-link" });
+
+        expect(res.status).toBe(302);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(res.header.location).toBe("#" + "?lang=en");
+        expect(session.getExtraData(USER_DATA)).toBeUndefined();
+        expect(session.getExtraData(CHECK_YOUR_ANSWERS_FLAG)).toBeUndefined();
+    });
+});


### PR DESCRIPTION
**Short description outlining key changes/additions**

- Added new section to confirmation view with 2 links as per prototype: verify another client and authorised agent account.
- New controller with GET method to clear the USER_DATA and CHECK_YOUR_ANSWERS_FLAG session variables to allow user to go through verify journey again.
- Redirecting user to correct url.
- Unit test class for new controller.

**JIRA Ticket Number**

[IDVA5-1482](https://companieshouse.atlassian.net/browse/IDVA5-1482)

**Type of change**
 
- [ ] Bug fix
- [X]  New feature
- [ ]  Breaking change
- [ ]  Infrastructure change

**Pull request checklist**

- [X]  I have added unit tests for new code that I have added
- [ ]  I have added/updated functional tests where appropriate
- [X]  The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

**An exhaustive list of peer review checks can be read** [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)

[IDVA5-1482]: https://companieshouse.atlassian.net/browse/IDVA5-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ