### PR TITLE
Set returnUrl to base url for logged in users

### DIFF
--- a/src/middleware/acsp_authentication_middleware.ts
+++ b/src/middleware/acsp_authentication_middleware.ts
@@ -8,7 +8,7 @@ export const acspAuthMiddleware = (req: Request, res: Response, next: NextFuncti
     const acspNumber: string = getLoggedInAcspNumber(req.session);
     const authMiddlewareConfig: AuthOptions = {
         chsWebUrl: CHS_URL,
-        returnUrl: BASE_URL + PERSONS_NAME,
+        returnUrl: BASE_URL,
         acspNumber
     };
     return acspManageUsersAuthMiddleware(authMiddlewareConfig)(req, res, next);

--- a/src/middleware/authentication_middleware.ts
+++ b/src/middleware/authentication_middleware.ts
@@ -7,7 +7,7 @@ export const authenticationMiddleware = (req: Request, res: Response, next: Next
 
     const authMiddlewareConfig: AuthOptions = {
         chsWebUrl: CHS_URL,
-        returnUrl: BASE_URL + PERSONS_NAME
+        returnUrl: BASE_URL
     };
     return authMiddleware(authMiddlewareConfig)(req, res, next);
 };

--- a/test/src/middleware/acsp_authentication_middleware.test.ts
+++ b/test/src/middleware/acsp_authentication_middleware.test.ts
@@ -23,7 +23,7 @@ const next = jest.fn();
 
 const expectedAuthMiddlewareConfig: AuthOptions = {
     chsWebUrl: "http://chs.local",
-    returnUrl: BASE_URL + PERSONS_NAME,
+    returnUrl: BASE_URL,
     acspNumber: "ABC123"
 };
 

--- a/test/src/middleware/authentication_middleware.test.ts
+++ b/test/src/middleware/authentication_middleware.test.ts
@@ -20,7 +20,7 @@ const next = jest.fn();
 
 const expectedAuthMiddlewareConfig: AuthOptions = {
     chsWebUrl: "http://chs.local",
-    returnUrl: BASE_URL + PERSONS_NAME
+    returnUrl: BASE_URL
 };
 
 describe("authentication middleware tests", () => {


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1549

Set returnUrl to BASE_URL so users start from start page after logging in, or if they are already logged in in both authMiddleWare and acspAuthMiddleWare.