### PR TITLE
IDVA5-1557 Preventing the user going back after application submission

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,11 +16,12 @@ import {
     PIWIK_URL,
     PIWIK_SITE_ID
 } from "./utils/properties";
-import { BASE_URL, HEALTHCHECK, ACCESSIBILITY_STATEMENT } from "./types/pageURL";
+import { BASE_URL, HEALTHCHECK, ACCESSIBILITY_STATEMENT, CONFIRMATION, CONFIRMATION_REDIRECT } from "./types/pageURL";
 import { commonTemplateVariablesMiddleware } from "./middleware/common_variables_middleware";
 import { getLocalesService, selectLang } from "./utils/localise";
 import { ErrorService } from "./services/errorService";
 import { acspAuthMiddleware } from "./middleware/acsp_authentication_middleware";
+import { applicationSubmittedMiddlware } from "./middleware/application_submitted_middleware";
 const app = express();
 
 const nunjucksEnv = nunjucks.configure([path.join(__dirname, "views"),
@@ -57,6 +58,7 @@ app.use(cookieParser());
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, sessionMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, authenticationMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, acspAuthMiddleware);
+app.use(`^(?!(${BASE_URL}${HEALTHCHECK}|${BASE_URL}${CONFIRMATION}|${BASE_URL}${CONFIRMATION_REDIRECT}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, applicationSubmittedMiddlware);
 app.use(commonTemplateVariablesMiddleware);
 
 // Channel all requests through router dispatch

--- a/src/controllers/checkYourAnswers.ts
+++ b/src/controllers/checkYourAnswers.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import * as config from "../config";
 import { BASE_URL, CHECK_YOUR_ANSWERS, CONFIRM_IDENTITY_VERIFICATION, CONFIRMATION } from "../types/pageURL";
-import { USER_DATA, REFERENCE, MATOMO_BUTTON_CLICK, CHECK_YOUR_ANSWERS_FLAG, ACSP_DETAILS } from "../utils/constants";
+import { USER_DATA, REFERENCE, MATOMO_BUTTON_CLICK, CHECK_YOUR_ANSWERS_FLAG, ACSP_DETAILS, DETAILS_SUBMITTED } from "../utils/constants";
 import { ClientData } from "../model/ClientData";
 import { Session } from "@companieshouse/node-session-handler";
 import { FormatService } from "../services/formatService";
@@ -110,6 +110,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         await sendVerifiedClientDetails(verifiedClientData).then(identity => {
             logger.info("response from verification api" + JSON.stringify(identity));
             saveDataInSession(req, REFERENCE, identity?.id);
+            saveDataInSession(req, DETAILS_SUBMITTED, true);
             res.redirect(addLangToUrl(BASE_URL + CONFIRMATION, lang));
         }).catch(error => {
             logger.error("Verification-Api error" + JSON.stringify(error));

--- a/src/controllers/confirmationRedirectController.ts
+++ b/src/controllers/confirmationRedirectController.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { Session } from "@companieshouse/node-session-handler";
-import { CHECK_YOUR_ANSWERS_FLAG, USER_DATA } from "../utils/constants";
+import { CHECK_YOUR_ANSWERS_FLAG, DETAILS_SUBMITTED, REFERENCE, USER_DATA } from "../utils/constants";
 import { addLangToUrl, selectLang } from "../utils/localise";
 import { AUTHORISED_AGENT, BASE_URL } from "../types/pageURL";
 
@@ -11,6 +11,8 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     // Clear session data + CYA flag
     session.deleteExtraData(USER_DATA);
     session.deleteExtraData(CHECK_YOUR_ANSWERS_FLAG);
+    session.deleteExtraData(DETAILS_SUBMITTED);
+    session.deleteExtraData(REFERENCE);
 
     const id = req.query.id as string;
     let redirectUrl = "";

--- a/src/middleware/application_submitted_middleware.ts
+++ b/src/middleware/application_submitted_middleware.ts
@@ -1,0 +1,17 @@
+import { Session } from "@companieshouse/node-session-handler";
+import { Request, Response, NextFunction } from "express";
+import { DETAILS_SUBMITTED } from "../utils/constants";
+import { addLangToUrl, selectLang } from "../utils/localise";
+import { BASE_URL, CONFIRMATION } from "../types/pageURL";
+
+export const applicationSubmittedMiddlware = (req: Request, res: Response, next: NextFunction): unknown => {
+    const lang = selectLang(req.query.lang);
+    const session: Session = req.session as any as Session;
+    const hasApplicationBeenSubmitted: boolean = session.getExtraData(DETAILS_SUBMITTED)!;
+
+    if (hasApplicationBeenSubmitted) {
+        res.redirect(addLangToUrl(BASE_URL + CONFIRMATION, lang));
+    } else {
+        return next();
+    }
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,6 +4,7 @@ export const PREVIOUS_PAGE_URL: string = "previouspageurl";
 export const REFERENCE = "reference";
 export const CHECK_YOUR_ANSWERS_FLAG = "checkYourAnswersFlag";
 export const ACSP_DETAILS = "acspDetails";
+export const DETAILS_SUBMITTED = "detailsSubmitted";
 
 // Matomo
 export const MATOMO_BUTTON_CLICK = "Click button";

--- a/test/src/controllers/checkYourAnswers.test.ts
+++ b/test/src/controllers/checkYourAnswers.test.ts
@@ -20,6 +20,18 @@ describe("GET" + CHECK_YOUR_ANSWERS, () => {
 });
 
 describe("POST " + CHECK_YOUR_ANSWERS, () => {
+    it("should return status 400 if checkbox is not selected", async () => {
+        const res = await router.post(BASE_URL + CHECK_YOUR_ANSWERS).send({
+            address: "Flat 1 Baker Street<br>Second Floor<br>London<br>Greater London<br>United Kingdom<br>NW1 6XE",
+            dateOfBirth: "07 July 1998",
+            whenIdentityChecksCompleted: "07 July 2024",
+            documentsChecked: "• Biometric or machine readable passport<br>• Irish passport card",
+            checkYourAnswerDeclaration: ""
+        });
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Select to confirm the declaration");
+    });
+
     it("should return status 302 after redirect", async () => {
         await mockSendVerifiedClientDetails.mockResolvedValueOnce(undefined);
         const res = await router.post(BASE_URL + CHECK_YOUR_ANSWERS).send({
@@ -31,17 +43,5 @@ describe("POST " + CHECK_YOUR_ANSWERS, () => {
         });
         expect(res.status).toBe(302);
         expect(res.header.location).toBe(BASE_URL + CONFIRMATION + "?lang=en");
-    });
-
-    it("should return status 400 if checkbox is not selected", async () => {
-        const res = await router.post(BASE_URL + CHECK_YOUR_ANSWERS).send({
-            address: "Flat 1 Baker Street<br>Second Floor<br>London<br>Greater London<br>United Kingdom<br>NW1 6XE",
-            dateOfBirth: "07 July 1998",
-            whenIdentityChecksCompleted: "07 July 2024",
-            documentsChecked: "• Biometric or machine readable passport<br>• Irish passport card",
-            checkYourAnswerDeclaration: ""
-        });
-        expect(res.status).toBe(400);
-        expect(res.text).toContain("Select to confirm the declaration");
     });
 });


### PR DESCRIPTION
Added application submitted middleware to check if application has been submitted to prevent the user going back and resubmitting the same application twice 

Clearing the session on confirmation redirect controller to clear the application submitted flag and the previous application reference number