### PR TITLE
IDVA5-1543 Override padding style

### DIFF
--- a/assets/src/scss/__global.scss
+++ b/assets/src/scss/__global.scss
@@ -113,7 +113,7 @@ $govuk-global-styles: true;
 @media (min-width: 769px) {
   #global-nav nav #navigation {
       border-bottom: 1px solid #b1b4b6;
-      padding-bottom: 10px;
+      padding-bottom: 10px !important;
   }
 }
 


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1543

During testing, the padding was not being applied due to stylesheet setting it to 0. I am overriding this to apply the padding-bottom to 10px. Have tested in cidev and looks good now.

![image](https://github.com/user-attachments/assets/ed85be22-730a-41ee-b8c7-17975852d5fa)