### PR TITLE
IDVA5-1556 Bug: Storing Date as String to save in session

### DIFF
--- a/src/controllers/dateOfBirthController.ts
+++ b/src/controllers/dateOfBirthController.ts
@@ -78,7 +78,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 req.body["dob-month"] - 1,
                 req.body["dob-day"]
             );
-            clientData.dateOfBirth = dateOfBirth;
+            clientData.dateOfBirth = dateOfBirth.toISOString();
         }
 
         if (previousPageUrl === addLangToUrl(BASE_URL + CHECK_YOUR_ANSWERS, lang)) {

--- a/src/controllers/idDocumentDetailsController.ts
+++ b/src/controllers/idDocumentDetailsController.ts
@@ -59,7 +59,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     );
 
     const documentDetailsService = new IdDocumentDetailsService();
-    const errorArray = documentDetailsService.errorListDisplay(errorList.array(), formattedDocumentsChecked, lang, clientData.whenIdentityChecksCompleted!);
+    const whenIdentityChecksCompleted = new Date(clientData.whenIdentityChecksCompleted!);
+    const errorArray = documentDetailsService.errorListDisplay(errorList.array(), formattedDocumentsChecked, lang, whenIdentityChecksCompleted!);
     if (errorArray.length) {
         const pageProperties = getPageProperties(formatValidationError(errorArray, lang));
         res.status(400).render(config.ID_DOCUMENT_DETAILS, {

--- a/src/controllers/idDocumentDetailsController.ts
+++ b/src/controllers/idDocumentDetailsController.ts
@@ -60,7 +60,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 
     const documentDetailsService = new IdDocumentDetailsService();
     const whenIdentityChecksCompleted = new Date(clientData.whenIdentityChecksCompleted!);
-    const errorArray = documentDetailsService.errorListDisplay(errorList.array(), formattedDocumentsChecked, lang, whenIdentityChecksCompleted!);
+    const errorArray = documentDetailsService.errorListDisplay(errorList.array(), formattedDocumentsChecked, lang, whenIdentityChecksCompleted);
     if (errorArray.length) {
         const pageProperties = getPageProperties(formatValidationError(errorArray, lang));
         res.status(400).render(config.ID_DOCUMENT_DETAILS, {

--- a/src/controllers/whenIdentityChecksCompletedController.ts
+++ b/src/controllers/whenIdentityChecksCompletedController.ts
@@ -74,7 +74,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 req.body["wicc-month"] - 1,
                 req.body["wicc-day"]
             );
-            clientData.whenIdentityChecksCompleted = whenIdentityChecksCompleted;
+            clientData.whenIdentityChecksCompleted = whenIdentityChecksCompleted.toISOString();
         }
         saveDataInSession(req, USER_DATA, clientData);
 

--- a/src/model/ClientData.ts
+++ b/src/model/ClientData.ts
@@ -5,13 +5,13 @@ export interface ClientData {
     firstName?: string;
     middleName?: string;
     lastName?: string;
-    dateOfBirth?: Date;
+    dateOfBirth?: Date | string;
     address?: Address;
     documentsChecked?: string[];
     idDocumentDetails?: DocumentDetails[];
     emailAddress?: string;
     confirmEmailAddress?: string;
     howIdentityDocsChecked?: string;
-    whenIdentityChecksCompleted?: Date;
+    whenIdentityChecksCompleted?: Date | string;
     confirmIdentityVerified?: string;
 }

--- a/src/services/idDocumentDetailsService.ts
+++ b/src/services/idDocumentDetailsService.ts
@@ -34,7 +34,7 @@ export class IdDocumentDetailsService {
         saveDataInSession(req, USER_DATA, clientData);
     }
 
-    public errorListDisplay = (errors: any[], documentsChecked: string[], lang: string, whenIdDocsChecked: Date | string): any[] => {
+    public errorListDisplay = (errors: any[], documentsChecked: string[], lang: string, whenIdDocsChecked: Date): any[] => {
         const newErrorArray: any[] = [];
         errors.forEach((element) => {
             const errorText = element.msg;
@@ -57,7 +57,7 @@ export class IdDocumentDetailsService {
     };
 }
 
-const getErrorForExpiryDate = (docName:string, errorMessage: string, errorText: string, whenIdDocsChecked:Date | string) => {
+const getErrorForExpiryDate = (docName:string, errorMessage: string, errorText: string, whenIdDocsChecked:Date) => {
     whenIdDocsChecked = new Date(whenIdDocsChecked);
     if ((docName === "UK accredited PASS card" && errorText === "noExpiryDate") ||
         (docName === "UK HM Armed Forces Veteran Card" && errorText === "noExpiryDate")) {

--- a/src/services/idDocumentDetailsService.ts
+++ b/src/services/idDocumentDetailsService.ts
@@ -34,7 +34,7 @@ export class IdDocumentDetailsService {
         saveDataInSession(req, USER_DATA, clientData);
     }
 
-    public errorListDisplay = (errors: any[], documentsChecked: string[], lang: string, whenIdDocsChecked: Date): any[] => {
+    public errorListDisplay = (errors: any[], documentsChecked: string[], lang: string, whenIdDocsChecked: Date | string): any[] => {
         const newErrorArray: any[] = [];
         errors.forEach((element) => {
             const errorText = element.msg;
@@ -57,7 +57,8 @@ export class IdDocumentDetailsService {
     };
 }
 
-const getErrorForExpiryDate = (docName:string, errorMessage: string, errorText: string, whenIdDocsChecked:Date) => {
+const getErrorForExpiryDate = (docName:string, errorMessage: string, errorText: string, whenIdDocsChecked:Date | string) => {
+    whenIdDocsChecked = new Date(whenIdDocsChecked);
     if ((docName === "UK accredited PASS card" && errorText === "noExpiryDate") ||
         (docName === "UK HM Armed Forces Veteran Card" && errorText === "noExpiryDate")) {
         return "";

--- a/src/services/idDocumentDetailsService.ts
+++ b/src/services/idDocumentDetailsService.ts
@@ -58,7 +58,6 @@ export class IdDocumentDetailsService {
 }
 
 const getErrorForExpiryDate = (docName:string, errorMessage: string, errorText: string, whenIdDocsChecked:Date) => {
-    whenIdDocsChecked = new Date(whenIdDocsChecked);
     if ((docName === "UK accredited PASS card" && errorText === "noExpiryDate") ||
         (docName === "UK HM Armed Forces Veteran Card" && errorText === "noExpiryDate")) {
         return "";

--- a/src/services/identityVerificationService.ts
+++ b/src/services/identityVerificationService.ts
@@ -96,9 +96,9 @@ export class IdentityVerificationService {
                 surname: clientData.lastName!,
                 created: new Date()
             },
-            verificationDate: clientData.whenIdentityChecksCompleted!,
+            verificationDate: new Date(clientData.whenIdentityChecksCompleted!),
             validationMethod: clientData.howIdentityDocsChecked!,
-            dateOfBirth: clientData.dateOfBirth!,
+            dateOfBirth: new Date(clientData.dateOfBirth!),
             currentAddress: {
                 addressLine1: clientData.address?.line1!,
                 addressLine2: clientData.address?.line2,

--- a/src/validations/idDocumentDetails.ts
+++ b/src/validations/idDocumentDetails.ts
@@ -95,7 +95,7 @@ export const validDataChecker = (day: string, month: string | undefined, year: s
 
 const validateAgainstWhenIdDocsChecked = (day: number, month: number, year: number, req: Session): void => {
     const clientData: ClientData = req?.getExtraData(USER_DATA)!;
-    const whenIdDocsChecked: Date = clientData.whenIdentityChecksCompleted!;
+    const whenIdDocsChecked: Date | string = clientData.whenIdentityChecksCompleted!;
     const expiryDate = new Date(year, month - 1, day);
     if (expiryDate <= whenIdDocsChecked) {
         throw new Error("dateAfterIdChecksDone");

--- a/src/validations/idDocumentDetails.ts
+++ b/src/validations/idDocumentDetails.ts
@@ -95,7 +95,7 @@ export const validDataChecker = (day: string, month: string | undefined, year: s
 
 const validateAgainstWhenIdDocsChecked = (day: number, month: number, year: number, req: Session): void => {
     const clientData: ClientData = req?.getExtraData(USER_DATA)!;
-    const whenIdDocsChecked: Date | string = clientData.whenIdentityChecksCompleted!;
+    const whenIdDocsChecked: Date = new Date(clientData.whenIdentityChecksCompleted!);
     const expiryDate = new Date(year, month - 1, day);
     if (expiryDate <= whenIdDocsChecked) {
         throw new Error("dateAfterIdChecksDone");


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1556

**Bug:** for Date of Birth and Identity Check Completed Date screens, we could not input a year before 1970 even within validation range. When you input it and continue, when pressing back the field is empty. Similarly when you continue through to CYA the values are showing blank.

**Changes:** Javascript Date object measures from 1st Jan 1970 so dates before that have a negative timestamp which was throwing an error when trying to save this into the session.

I changed the type for dateOfBirth and whenIdentityChecksCompleted from Date to also include string as the approach to use. Converting the date to a string before saving into the session. Then in the GET methods this is converting back into a Date object being displayed on screens. 