### PR TITLE
Updating validation id document number field

### DIFF
--- a/locales/cy/id-document-details.json
+++ b/locales/cy/id-document-details.json
@@ -10,7 +10,7 @@
     "chooseCountryhint":"This is usually shown on the first page of the welsh ",
     "error-docNumberInput": "Enter the details for the {doc selected} welsh",
     "error-docNumberLength": "{doc selected} must be 50 characters or fewer welsh",
-    "error-docNumberFormat": "{doc selected} must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes welsh",
+    "error-docNumberFormat": "{doc selected} must only include letters a to z, numbers and common special characters such as hyphens, spaces and apostrophes welsh",
     "error-noExpiryDate" : "Enter the expiry date for {doc selected} welsh",
     "error-noExpiryDayMonth" : "{doc selected} must include a day and a month welsh",
     "error-noExpiryDayYear" : "{doc selected} must include a day and a year welsh",

--- a/locales/en/id-document-details.json
+++ b/locales/en/id-document-details.json
@@ -10,7 +10,7 @@
     "chooseCountryhint":"This is usually shown on the first page of the ",
     "error-docNumberInput": "Enter the details for the {doc selected}",
     "error-docNumberLength": "{doc selected} must be 50 characters or fewer",
-    "error-docNumberFormat": "{doc selected} must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes",
+    "error-docNumberFormat": "{doc selected} must only include letters a to z, numbers and common special characters such as hyphens, spaces and apostrophes",
     "error-noExpiryDate" : "Enter the expiry date for {doc selected}",
     "error-noExpiryDayMonth" : "{doc selected} must include a day and a month",
     "error-noExpiryDayYear" : "{doc selected} must include a day and a year",

--- a/src/validations/idDocumentDetails.ts
+++ b/src/validations/idDocumentDetails.ts
@@ -3,6 +3,8 @@ import { ClientData } from "../model/ClientData";
 import { Session } from "@companieshouse/node-session-handler";
 import { USER_DATA } from "../utils/constants";
 
+const documentNumberFormat:RegExp = /^[A-Za-z0-9\-',\s]*$/;
+
 const idDocumentDetailsValidator = (): ValidationChain[] => {
     const documentDetailsValidatorErrors: ValidationChain[] = [];
     const numberOfDocumentDetails = 16;
@@ -12,8 +14,8 @@ const idDocumentDetailsValidator = (): ValidationChain[] => {
             (
                 body(`documentNumber_${i}`)
                     .if(body(`documentNumber_${i}`).exists()).trim().notEmpty().withMessage("docNumberInput")
+                    .matches(documentNumberFormat).withMessage("docNumberFormat").bail()
                     .bail().isLength({ max: 50 }).withMessage("docNumberLength")
-                    .bail().isAlphanumeric().withMessage("docNumberFormat")
             ));
 
         documentDetailsValidatorErrors.push(


### PR DESCRIPTION
Adding RegEx to `idDocumentsDetails.ts` validator which validates the selected ID document number(s) against the following conditions:

- Can contain all letters A-Z (both uppercase and lowercase)
- Can contain all numbers (0-9)
- Can contain a hyphen (-)
- Can contain an apostrophe (')
- Can contain a comma
- Can contain spaces