### PR TITLE
Updating navbar links

### DIFF
--- a/src/middleware/common_variables_middleware.ts
+++ b/src/middleware/common_variables_middleware.ts
@@ -1,6 +1,6 @@
 import { Handler } from "express";
 import { CHS_MONITOR_GUI_URL } from "../utils/properties";
-import { getLoggedInUserEmail } from "../utils/session";
+import { getLoggedInAcspNumber, getLoggedInUserEmail } from "../utils/session";
 
 /**
  * Populates variables for use in templates that are used on multiple pages.
@@ -13,11 +13,20 @@ import { getLoggedInUserEmail } from "../utils/session";
  */
 export const commonTemplateVariablesMiddleware: Handler = (req, res, next) => {
 
+    const acspNumber: string = getLoggedInAcspNumber(req.session);
+
     // Populate user email for use in signout bar.
     const email = getLoggedInUserEmail(req.session);
     if (email !== undefined) {
         res.locals.userEmail = email;
     }
+
     res.locals.chsMonitorGuiUrl = CHS_MONITOR_GUI_URL;
+
+    // Setting value for 'Authorised agent' link to show/hide on navbar
+    if (acspNumber !== undefined) {
+        res.locals.displayAuthorisedAgent = "yes";
+    }
+
     next();
 };

--- a/src/views/partials/nav/top.njk
+++ b/src/views/partials/nav/top.njk
@@ -1,3 +1,3 @@
 {% from "navbar.njk" import addPredefinedNavbar %}
 {% set lang = i18n %}
-{{ addPredefinedNavbar(userEmail, chsMonitorGuiUrl, lang, "yes") }}
+{{ addPredefinedNavbar(userEmail, chsMonitorGuiUrl, lang, displayAuthorisedAgent, "yes") }}

--- a/test/mocks/session.mock.ts
+++ b/test/mocks/session.mock.ts
@@ -6,13 +6,11 @@ import { UserProfileKeys } from "@companieshouse/node-session-handler/lib/sessio
 import { IAccessToken, ISignInInfo } from "@companieshouse/node-session-handler/lib/session/model/SessionInterfaces";
 
 export const userMail = "userWithPermission@ch.gov.uk";
-export const acspNumber = "1234";
 export const ACCESS_TOKEN_MOCK: IAccessToken = { [AccessTokenKeys.AccessToken]: "accessToken" };
 export const REFRESH_TOKEN_MOCK: IAccessToken = { [AccessTokenKeys.RefreshToken]: "refreshToken" };
 
 const SIGN_IN_INFO = {
     [SignInInfoKeys.SignedIn]: 1,
-    [SignInInfoKeys.AcspNumber]: acspNumber,
     [SignInInfoKeys.UserProfile]: { [UserProfileKeys.Email]: userMail },
     [SignInInfoKeys.AccessToken]: {
         ...ACCESS_TOKEN_MOCK,

--- a/test/mocks/session.mock.ts
+++ b/test/mocks/session.mock.ts
@@ -6,11 +6,13 @@ import { UserProfileKeys } from "@companieshouse/node-session-handler/lib/sessio
 import { IAccessToken, ISignInInfo } from "@companieshouse/node-session-handler/lib/session/model/SessionInterfaces";
 
 export const userMail = "userWithPermission@ch.gov.uk";
+export const acspNumber = "1234";
 export const ACCESS_TOKEN_MOCK: IAccessToken = { [AccessTokenKeys.AccessToken]: "accessToken" };
 export const REFRESH_TOKEN_MOCK: IAccessToken = { [AccessTokenKeys.RefreshToken]: "refreshToken" };
 
 const SIGN_IN_INFO = {
     [SignInInfoKeys.SignedIn]: 1,
+    [SignInInfoKeys.AcspNumber]: acspNumber,
     [SignInInfoKeys.UserProfile]: { [UserProfileKeys.Email]: userMail },
     [SignInInfoKeys.AccessToken]: {
         ...ACCESS_TOKEN_MOCK,

--- a/test/src/middleware/common_variables_middleware.test.ts
+++ b/test/src/middleware/common_variables_middleware.test.ts
@@ -1,0 +1,37 @@
+import { NextFunction, Request, Response } from "express";
+import { commonTemplateVariablesMiddleware } from "../../../src/middleware/common_variables_middleware";
+import * as sessionUtils from "../../../src/utils/session";
+import { createResponse } from "node-mocks-http";
+
+const getLoggedInAcspNumberSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getLoggedInAcspNumber");
+
+const req: Request = {} as Request;
+let res: Response = {} as Response;
+const next: NextFunction = jest.fn();
+
+describe("common template variables middleware tests", () => {
+
+    beforeEach(() => {
+        res = createResponse({
+            locals: {}
+        });
+    });
+
+    it("should display 'Your companies' navbar link when acsp number is valid", () => {
+        getLoggedInAcspNumberSpy.mockReturnValue("AP12345");
+
+        commonTemplateVariablesMiddleware(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.locals.displayAuthorisedAgent).toBe("yes");
+    });
+
+    it("should not display 'Your companies' navbar link when acsp number is undefined", () => {
+        getLoggedInAcspNumberSpy.mockReturnValue(undefined);
+
+        commonTemplateVariablesMiddleware(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.locals.displayAuthorisedAgent).toBe(undefined);
+    });
+});

--- a/test/src/middleware/common_variables_middleware.test.ts
+++ b/test/src/middleware/common_variables_middleware.test.ts
@@ -17,7 +17,7 @@ describe("common template variables middleware tests", () => {
         });
     });
 
-    it("should display 'Your companies' navbar link when acsp number is valid", () => {
+    it("should display 'Authorised agent' navbar link when acsp number is valid", () => {
         getLoggedInAcspNumberSpy.mockReturnValue("AP12345");
 
         commonTemplateVariablesMiddleware(req, res, next);
@@ -26,7 +26,7 @@ describe("common template variables middleware tests", () => {
         expect(res.locals.displayAuthorisedAgent).toBe("yes");
     });
 
-    it("should not display 'Your companies' navbar link when acsp number is undefined", () => {
+    it("should not display 'Authorised agent' navbar link when acsp number is undefined", () => {
         getLoggedInAcspNumberSpy.mockReturnValue(undefined);
 
         commonTemplateVariablesMiddleware(req, res, next);


### PR DESCRIPTION
Fix for bug ticket:
[IDVA5-1633](https://companieshouse.atlassian.net/browse/IDVA5-1633?atlOrigin=eyJpIjoiYTIxMmE4ODMzOGI4NDg3NTgyOGViNGI5MjM1NTI5OTIiLCJwIjoiaiJ9)

- Updating navbar to include 'Your companies' link on verify service.
The structure of the navbar including updated flag status can be viewed here: [ch-node-utils](https://github.com/companieshouse/ch-node-utils/blob/5372ed77a4b4ad9c6fc94885071cf884135c4f40/templates/navbar.njk#L65)

- Reflected `acsp-web` navbar logic under `common_variables_middleware` to include 'Authorised agent' link only if the user has a valid ACSP number

[IDVA5-1635]: https://companieshouse.atlassian.net/browse/IDVA5-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[IDVA5-1633]: https://companieshouse.atlassian.net/browse/IDVA5-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ