### PR TITLE
Bug fix for optional id doc expiry date

### DIFF
--- a/locales/cy/check-your-answers.json
+++ b/locales/cy/check-your-answers.json
@@ -8,6 +8,7 @@
     "confirmSend": "Cadarnhau ac anfon",
     "details": "details welsh",
     "number": "number welsh",
+    "dateNotProvided": "Not provided welsh",
     "error-checkYourAnswerEmpty":"Dewiswch i gadarnhau'r datganiad"
 
 

--- a/locales/en/check-your-answers.json
+++ b/locales/en/check-your-answers.json
@@ -8,5 +8,6 @@
     "confirmSend": "Confirm and send",
     "details": "details",
     "number": "number",
+    "dateNotProvided": "Not provided",
     "error-checkYourAnswerEmpty":"Select to confirm the declaration"
 }

--- a/src/controllers/idDocumentDetailsController.ts
+++ b/src/controllers/idDocumentDetailsController.ts
@@ -73,7 +73,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             countryList: countryList
         });
     } else {
-        documentDetailsService.saveIdDocumentDetails(req, clientData, formattedDocumentsChecked);
+        documentDetailsService.saveIdDocumentDetails(req, clientData, formattedDocumentsChecked, locales.i18nCh.resolveNamespacesKeys(lang));
         const checkYourAnswersFlag = session?.getExtraData(CHECK_YOUR_ANSWERS_FLAG);
 
         if (checkYourAnswersFlag) {

--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -41,9 +41,9 @@ export class FormatService {
         return parts.join("<br>");
     }
 
-    public static formatDate (date?: Date): string {
+    public static formatDate (date?: Date, i18n?: any): string {
         if (!date) {
-            return "";
+            return i18n ? i18n.dateNotProvided : "";
         }
         if (!(date instanceof Date) || isNaN(date.getTime())) {
             throw new Error("Invalid date");

--- a/src/services/idDocumentDetailsService.ts
+++ b/src/services/idDocumentDetailsService.ts
@@ -7,7 +7,7 @@ import { resolveErrorMessage } from "../validations/validation";
 import { FormatService } from "./formatService";
 
 export class IdDocumentDetailsService {
-    public saveIdDocumentDetails = (req: Request, clientData: ClientData, formattedDocumentsChecked: string[]) => {
+    public saveIdDocumentDetails = (req: Request, clientData: ClientData, formattedDocumentsChecked: string[], i18n: any) => {
         const documentDetails: DocumentDetails[] = [];
         clientData.idDocumentDetails = documentDetails;
         for (let i = 0; i < formattedDocumentsChecked.length; i++) {
@@ -17,17 +17,20 @@ export class IdDocumentDetailsService {
             const expiryDateMonthId = "expiryDateMonth_" + j;
             const expiryDateYearId = "expiryDateYear_" + j;
             const countryOfIssueId = "countryInput_" + j;
-            const expiryDate = new Date(
-                req.body[expiryDateYearId],
-                req.body[expiryDateMonthId] - 1,
-                req.body[expiryDateDayId]
-            );
+            let expiryDate;
+            if (req.body[expiryDateYearId] && req.body[expiryDateMonthId] && req.body[expiryDateDayId]) {
+                expiryDate = new Date(
+                    req.body[expiryDateYearId],
+                    req.body[expiryDateMonthId] - 1,
+                    req.body[expiryDateDayId]
+                );
+            }
             documentDetails.push({
                 documentNumber: req.body[docNumberId],
                 expiryDate: expiryDate,
                 countryOfIssue: req.body[countryOfIssueId],
                 docName: formattedDocumentsChecked[i],
-                formattedExpiryDate: FormatService.formatDate(expiryDate)
+                formattedExpiryDate: FormatService.formatDate(expiryDate, i18n)
             });
         }
         if (clientData) {

--- a/test/src/services/idDocumentDetailsService.test.ts
+++ b/test/src/services/idDocumentDetailsService.test.ts
@@ -26,7 +26,7 @@ describe("IdDocumentDetailsService tests", () => {
         req.body.countryInput_1 = "India";
         const formattedDocs = ["UK biometric residence permit (BRP)"];
 
-        service.saveIdDocumentDetails(req, {}, formattedDocs);
+        service.saveIdDocumentDetails(req, {}, formattedDocs, {});
         const date = new Date(2025, 1, 28);
         expect(session.getExtraData(USER_DATA)).toEqual({
             idDocumentDetails: [{

--- a/test/src/services/idDocumentDetailsService.test.ts
+++ b/test/src/services/idDocumentDetailsService.test.ts
@@ -40,7 +40,6 @@ describe("IdDocumentDetailsService tests", () => {
     });
 
     it("should set formattedExpiryDate to 'Not provided' when expiry date is not given", () => {
-        // Arrange
         req = createRequest({});
         const session = getSessionRequestWithPermission();
         req.session = session;

--- a/test/src/services/idDocumentDetailsService.test.ts
+++ b/test/src/services/idDocumentDetailsService.test.ts
@@ -39,6 +39,33 @@ describe("IdDocumentDetailsService tests", () => {
         });
     });
 
+    it("should set formattedExpiryDate to 'Not provided' when expiry date is not given", () => {
+        // Arrange
+        req = createRequest({});
+        const session = getSessionRequestWithPermission();
+        req.session = session;
+        req.body.documentNumber_1 = "123456789";
+        req.body.expiryDateDay_1 = undefined;
+        req.body.expiryDateMonth_1 = undefined;
+        req.body.expiryDateYear_1 = undefined;
+        req.body.countryInput_1 = "England";
+
+        const formattedDocs = ["UK accredited PASS card"];
+        const i18n = { dateNotProvided: "Not provided" };
+
+        service.saveIdDocumentDetails(req, {}, formattedDocs, i18n);
+
+        expect(session.getExtraData(USER_DATA)).toEqual({
+            idDocumentDetails: [{
+                docName: "UK accredited PASS card",
+                documentNumber: "123456789",
+                expiryDate: undefined,
+                countryOfIssue: "England",
+                formattedExpiryDate: "Not provided"
+            }]
+        });
+    });
+
     it("should return an error array for expiry date errors", () => {
         const errors = [{ msg: "expiryDateInvalid", param: "expiryDateDay_1" }];
         const documentsChecked = ["UK biometric residence permit (BRP)"];

--- a/test/src/services/idDocumentDetailsService.test.ts
+++ b/test/src/services/idDocumentDetailsService.test.ts
@@ -39,7 +39,8 @@ describe("IdDocumentDetailsService tests", () => {
         });
     });
 
-    it("should set formattedExpiryDate to 'Not provided' when expiry date is not given", () => {
+    it("should set formattedExpiryDate to 'Not provided' when expiry date is not given for optional expiry date ID doc", () => {
+        // Arrange
         req = createRequest({});
         const session = getSessionRequestWithPermission();
         req.session = session;
@@ -49,14 +50,14 @@ describe("IdDocumentDetailsService tests", () => {
         req.body.expiryDateYear_1 = undefined;
         req.body.countryInput_1 = "England";
 
-        const formattedDocs = ["UK accredited PASS card"];
+        const formattedDocs = ["UK HM Armed Forces Veteran Card"];
         const i18n = { dateNotProvided: "Not provided" };
 
         service.saveIdDocumentDetails(req, {}, formattedDocs, i18n);
 
         expect(session.getExtraData(USER_DATA)).toEqual({
             idDocumentDetails: [{
-                docName: "UK accredited PASS card",
+                docName: "UK HM Armed Forces Veteran Card",
                 documentNumber: "123456789",
                 expiryDate: undefined,
                 countryOfIssue: "England",


### PR DESCRIPTION
Bug fix for ticket: [IDVA5-1617](https://companieshouse.atlassian.net/browse/IDVA5-1617?atlOrigin=eyJpIjoiZGNjY2U5ZTNlYTE1NDc4Njk3ODg3ZjQ4OTA4NWFkYzkiLCJwIjoiaiJ9)

Updating `saveIdDocumentDetails` method to check for data entered against document expiry date for optional expiry date ID documents. 

Optional expiry dates are handled for the following ID documents, where validation returns and empty string if no expiry date has been entered:
- UK Armed Forces Veteran Card 
- UK Accredited Passcard

`formatDate` method returns the string 'Not provided' on check your answers, when no expiry date has been provided (will only affect the above documents as validation for expiry date is not captured for the optional expiry date fields)


[IDVA5-1617]: https://companieshouse.atlassian.net/browse/IDVA5-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ