### PR TITLE
Renaming Prado hint text key as previously there was a conflict

### DIFF
--- a/locales/cy/id-document-details.json
+++ b/locales/cy/id-document-details.json
@@ -24,7 +24,7 @@
     "photoimmigrationDocHint": "This is 9 characters long. Welsh",
     "photoVisaHint": "This will have between 8 and 9 characters. Welsh",
     "ukFirearmsLicenceHint": "This will have between 6 and 10 characters. Welsh",
-    "photoIdPradoHint": "This needs to be a unique reference or number that is shown on the document. Welsh",
+    "photoIdPradoDetailsHint": "This needs to be a unique reference or number that is shown on the document. Welsh",
 
 
     "error-docNumberInput": "Enter the details for the {doc selected} welsh",

--- a/locales/en/id-document-details.json
+++ b/locales/en/id-document-details.json
@@ -24,7 +24,7 @@
     "photoimmigrationDocHint": "This is 9 characters long.",
     "photoVisaHint": "This will have between 8 and 9 characters.",
     "ukFirearmsLicenceHint": "This will have between 6 and 10 characters.",
-    "photoIdPradoHint": "This needs to be a unique reference or number that is shown on the document.",
+    "photoIdPradoDetailsHint": "This needs to be a unique reference or number that is shown on the document.",
 
 
     "error-docNumberInput": "Enter the details for the {doc selected}",

--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -186,7 +186,7 @@ export class FormatService {
                 immigration_document_photo_id: i18n.photoimmigrationDocHint,
                 visa_photo_id: i18n.photoVisaHint,
                 UK_firearms_licence: i18n.ukFirearmsLicenceHint,
-                PRADO_supported_photo_id: i18n.photoIdPradoHint
+                PRADO_supported_photo_id: i18n.photoIdPradoDetailsHint
             };
         }
         documents.forEach((doc) => {


### PR DESCRIPTION
Renaming Prado hint text key for id document details page as previously there was a conflict with another page.