### PR TITLE
IDVA5-1746 Matomo checkboxes and links global approach

### DIFF
--- a/src/views/check-your-answers/check-your-answers.njk
+++ b/src/views/check-your-answers/check-your-answers.njk
@@ -318,6 +318,9 @@
     }) }}
 
   </form>
-  
+
+  <script type="text/javascript" nonce={{ nonce | dump | safe }}>
+    ignoreCheckboxForThisPage = true;
+  </script>
 
 {% endblock main_content %}

--- a/src/views/check-your-answers/check-your-answers.njk
+++ b/src/views/check-your-answers/check-your-answers.njk
@@ -192,7 +192,7 @@
           {
             href: "/tell-companies-house-you-have-verified-someones-identity/how-were-identity-documents-checked" + "?lang=" + lang,
             text: i18n.checkAnswerDetailsChange,
-            visuallyHiddenText: i18n.optionUsed
+            visuallyHiddenText: i18n.howTheIdentityDocsWereChecked
           }
         ]
       }
@@ -209,7 +209,7 @@
           {
             href: identityDocHref,
             text: i18n.checkAnswerDetailsChange,
-            visuallyHiddenText: i18n.identityDoc
+            visuallyHiddenText: i18n.identityDocsThatWereChecked
           }
         ]
       }

--- a/src/views/confirm-home-address/confirm-home-address.njk
+++ b/src/views/confirm-home-address/confirm-home-address.njk
@@ -25,9 +25,4 @@
     }) }}
   </form>
 
-<!-- Calling Matomo event script to capture event actions based on page title -->
-<script nonce={{ nonce | dump | safe }}>
-  trackEventBasedOnPageTitle("edit-address-link", "{{title}}", "{{matomoLinkClick}}", "Edit address");
-</script>
-
 {% endblock main_content %}

--- a/src/views/confirm-identity-verification/confirm-identity-verification.njk
+++ b/src/views/confirm-identity-verification/confirm-identity-verification.njk
@@ -66,5 +66,8 @@
     }) }}
 </form>
 
+<script type="text/javascript" nonce={{ nonce | dump | safe }}>
+    ignoreCheckboxForThisPage = true;
+</script>
 
 {% endblock main_content %}

--- a/src/views/confirmation/confirmation.njk
+++ b/src/views/confirmation/confirmation.njk
@@ -188,9 +188,4 @@
   <p class="govuk-body">
     <a href={{authorisedAgentLink}} class="govuk-link" id="authorised-agent-account-link">{{ i18n.linkAuthorisedAgentAccount }}</a>
   </p>
-  <script nonce={{ nonce | dump | safe }}>
-    trackEventBasedOnPageTitle("verify-service-link", "{{title}}", "{{matomoLinkClick}}", "Tell Companies House about another identity you have verified");
-    trackEventBasedOnPageTitle("authorised-agent-account-link", "{{title}}", "{{matomoLinkClick}}", "View authorised agent account");
-    trackEventBasedOnPageTitle("feedback-survey-link", "{{title}}", "{{matomoLinkClick}}", "Survey link");
-  </script>
 {% endblock %}

--- a/src/views/home-address-list/home-address-list.njk
+++ b/src/views/home-address-list/home-address-list.njk
@@ -51,9 +51,4 @@
         <a href= {{ manualAddressLink }} class="govuk-link" id="enter-address-manually-link">{{ i18n.homeAddressManualLink }}</a>
     </p>
 
-<!-- Calling Matomo event script to capture event actions based on page title -->
-<script nonce={{ nonce | dump | safe }}>
-    trackEventBasedOnPageTitle("enter-address-manually-link", "{{title}}", "{{matomoLinkClick}}", "Enter address manually");
-</script>
-
 {% endblock main_content %}

--- a/src/views/home-address/home-address.njk
+++ b/src/views/home-address/home-address.njk
@@ -49,9 +49,4 @@
     </p>
   </form>
 
-<!-- Calling Matomo event script to capture event actions based on page title -->
-<script nonce={{ nonce | dump | safe }}>
-  trackEventBasedOnPageTitle("enter-address-manually-link", "{{title}}" + " - Tell Companies House you have verified someone’s identity", "{{matomoLinkClick}}", "Enter address manually");
-</script>
-
 {% endblock %}

--- a/src/views/how-identity-documents-checked/how-identity-documents-checked.njk
+++ b/src/views/how-identity-documents-checked/how-identity-documents-checked.njk
@@ -58,10 +58,4 @@
         }) }}
   </form>
 
-<!-- Calling Matomo event script to capture event actions based on page title -->
-<script nonce={{ nonce | dump | safe }}>
-    trackEventBasedOnPageTitle("identity-verification-standard-link-id", "{{title}}", "click-link", "Identity verification standard link");
-
-</script>
-
 {% endblock main_content %}

--- a/src/views/index/home.njk
+++ b/src/views/index/home.njk
@@ -84,10 +84,7 @@
     </form>
 
     <!-- Calling Matomo event function to capture event actions based on page title -->
-    <script nonce={{ nonce | dump | safe }}>
-        trackEventBasedOnPageTitle("identity-verification-standard-link", "{{title}}", "{{matomoLinkClick}}", "Our identity verification standard");
-        trackEventBasedOnPageTitle("read-the-guidance-verification-link", "{{title}}", "{{matomoLinkClick}}", "Guidance about verifying someone's identity for Companies House");
-  
+    <script nonce={{ nonce | dump | safe }}>  
 
         function trackStartNowEvent() {
             _paq.push(['trackGoal', "{{ PIWIK_START_GOAL_ID }}"]);

--- a/src/views/partials/piwik.njk
+++ b/src/views/partials/piwik.njk
@@ -31,6 +31,10 @@
 //  Dynamic text(s) and the id(s) to be obtained from the selected checkbox(es).
     var boxDetailsForAnalytics = new Map();
 
+//  The following flag is needed to be set as true in confirm-identity-verification and check-your-answers njk for checkboxes 
+//  to be ignored in the Matomo analytics.
+    var ignoreCheckboxForThisPage = false;
+
     $(function() {
       //  The condition below checks and prioritizes the customized Matomo analytics calls.
       //  It has to be defined under "analyticsWithCustomisedMatomoText()" function in the page where the customization is needed.
@@ -47,9 +51,11 @@
           
           //  The block below covers the Matomo analysis for the selected checkbox elements.
           if ($("input[type='checkbox']:checked").length > 0) {
-                $("input[type='checkbox']:checked").each(function() {
+            if(!ignoreCheckboxForThisPage) {
+              $("input[type='checkbox']:checked").each(function() {
                 boxDetailsForAnalytics.set($(this).val(),$(this).siblings("label").text().trim());
               });
+            }  
           }
 
           //  Finally Matomo analytics are recorded on page submission.
@@ -76,11 +82,16 @@
 
       //  The block below covers the Matomo analysis for the href clicks.
       $(document).on("click", "a", function() {
-            textOnHrefClick = $(this).text();
-            if(textOnHrefClick){
+        // Provide different email stop screen - removes user name from link analytics
+        if ($(this).attr('id') && $(this).attr('id') === "provide-different-email-link-id") {
+          textOnHrefClick = $(this).text().split('for')[0];
+        } else {
+          textOnHrefClick = $(this).text();
+        }  
+        if(textOnHrefClick){
               _paq.push(["trackEvent", eventCategory, textOnHrefClick]);
-            }
-          });
+        }
+      });
     });
 
     function matomoObliteration(textToBeChecked){

--- a/src/views/partials/piwik.njk
+++ b/src/views/partials/piwik.njk
@@ -25,6 +25,12 @@
     var textOnRadioSelection = "";
     var buttonSuffix = "";
     var eventCategory = "";
+
+//  Dynamic text to be obtained from the label of an href.
+    var textOnHrefClick = "";
+//  Dynamic text(s) and the id(s) to be obtained from the selected checkbox(es).
+    var boxDetailsForAnalytics = new Map();
+
     $(function() {
       //  The condition below checks and prioritizes the customized Matomo analytics calls.
       //  It has to be defined under "analyticsWithCustomisedMatomoText()" function in the page where the customization is needed.
@@ -32,16 +38,29 @@
         var eventCategory = matomoObliteration($(document).find("title").text().split(' -')[0]);
  
         $("form").on("submit",function() {
-          //  The block below covers the Matomo analysis for the radio element.
+          
+          //  The block below covers the Matomo analysis for the selected radio element.
           if ($("input[type='radio']:checked").length > 0) {
               buttonSuffix = "-"+$(this).find("input[type='radio']:checked").attr('value');
               textOnRadioSelection = matomoObliteration($(this).find("input[type='radio']:checked").siblings("label").text().trim());
           }
-          //  For other elements like check box and/or hrefs can be added further below like above.
+          
+          //  The block below covers the Matomo analysis for the selected checkbox elements.
+          if ($("input[type='checkbox']:checked").length > 0) {
+                $("input[type='checkbox']:checked").each(function() {
+                boxDetailsForAnalytics.set($(this).val(),$(this).siblings("label").text().trim());
+              });
+          }
 
           //  Finally Matomo analytics are recorded on page submission.
           if(textOnRadioSelection){
             _paq.push(["trackEvent", eventCategory, textOnRadioSelection]);
+          }
+
+          if(boxDetailsForAnalytics.size > 0){
+            boxDetailsForAnalytics.forEach((values, keys) => {
+              _paq.push(["trackEvent", eventCategory,values, keys]);
+            });
           }
 
           eventNameBtn = eventNameBtn+buttonSuffix;
@@ -54,9 +73,15 @@
       $("button").click(function() {
         eventNameBtn = $(this).text().toUpperCase();
       });
+
+      //  The block below covers the Matomo analysis for the href clicks.
+      $(document).on("click", "a", function() {
+            textOnHrefClick = $(this).text();
+            if(textOnHrefClick){
+              _paq.push(["trackEvent", eventCategory, textOnHrefClick]);
+            }
+          });
     });
-
-
 
     function matomoObliteration(textToBeChecked){
         var replacedRestrictedText = "<obliterated>";
@@ -76,8 +101,6 @@
          buttonSuffix = "-OPTED_ADDRESS";
           return replacedRestrictedText;
         }
-
-
         return textToBeChecked;
     }
 //  End of Matomo automation snippet
@@ -88,13 +111,4 @@
         <img src="{{PIWIK_URL}}/piwik.php?idsite={{PIWIK_SITE_ID}}" class="piwik-img" alt="" />
     </p>
 </noscript>
-<script nonce={{ nonce | dump | safe }}>
-// Function to add event categories base on page title
-function trackEventBasedOnPageTitle(elementId, eventCategory, eventName) {
-    document.getElementById(elementId)
-    .addEventListener("click", () => {
-        _paq.push(["trackEvent", eventCategory, eventName]);
-    });
-}
-</script>
 <!-- Matomo Ends -->

--- a/src/views/partials/print_button.njk
+++ b/src/views/partials/print_button.njk
@@ -26,7 +26,6 @@
 
 <!-- Calling Matomo event script to capture event actions based on page title -->
 <script nonce={{ nonce | dump | safe }}>
-  trackEventBasedOnPageTitle("print-button", "{{title}}", "Print identity verification details");
   // Add event listener to print screen button
   document.getElementById("print-button")
     .addEventListener("click", () => {

--- a/src/views/provide-different-email/provide-different-email.njk
+++ b/src/views/provide-different-email/provide-different-email.njk
@@ -15,8 +15,4 @@
         <a id="provide-different-email-link-id" href="/tell-companies-house-you-have-verified-someones-identity/what-is-their-email-address">{{ i18n.provideDifferentEmailLink }}{{ firstName }} {{ lastName }}</a>.
     </p>
 
-    <script nonce={{ nonce | dump | safe }}>
-        trackEventBasedOnPageTitle("provide-different-email-link-id", "{{title}}", "click-link", "provide different email link");
-    </script>
-
 {% endblock main_content %}


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1746

- Replaced incorrect variables 'optionUsed' and 'identityDoc' visually hidden labels as these were not set anywhere and were coming blank in analytics. Correct labels added now.
- ignoreCheckboxForThisPage = true added to check-your-answers and confirm-identity-verification njks. This is because these declaration checkbox labels contain multiple sensitive info e.g. name, company, date and were not being tracked previously so I am ignoring them here.
- Removed trackEventBasedOnPageTitle function and references in njks
- piwik.njk changes are commented but handle href links and checkboxes analytics