### PR TITLE
Fixing issue with start now matomo goal not registering

### DIFF
--- a/src/views/index/home.njk
+++ b/src/views/index/home.njk
@@ -83,12 +83,14 @@
         </p>
     </form>
 
-    <!-- Calling Matomo event function to capture event actions based on page title -->
-    <script nonce={{ nonce | dump | safe }}>  
-
-        function trackStartNowEvent() {
+    <script nonce={{ nonce | dump | safe }}> 
+    
+        // Matomo tracking code to track event goal on click of start now button
+        function startNowEventListener () {
+            document.getElementById("start-now").addEventListener("click", () => {
             _paq.push(['trackGoal', "{{ PIWIK_START_GOAL_ID }}"]);
-        };
+        });
+        }
 
         if (document.readyState === "loading") {
             document.addEventListener("DOMContentLoaded", function (e) {


### PR DESCRIPTION
Fix for bug ticket:
[IDVA5-1785](https://companieshouse.atlassian.net/browse/IDVA5-1785)

Updating Matomo script within the home page of the Verification service to correctly call the relevant script for tracking the 'Start now' goal, upon clicking the 'Start now' button.
Goal was not being tracked upon clicking the start now button, due to the function `startNowEventListener()` not being defined.


[IDVA5-1785]: https://companieshouse.atlassian.net/browse/IDVA5-1785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ