### PR TITLE
Removing unused matomo function

### DIFF
--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -39,8 +39,8 @@
         {% endif %}
 
 
-<div id="templateName" data-id='{{templateTitle}}' hidden></div>
-<script nonce={{ nonce | dump | safe }} type="application/javascript">
+<div id="templateName" data-id="{{templateTitle}}" hidden></div>
+<script type="application/javascript" nonce={{ nonce | dump | safe }}>
   window.SERVICE_NAME = "Tell Companies House you have verified someone's identity";
   window.PIWIK_URL = '{{ PIWIK_URL }}'
   window.PIWIK_SITE_ID = '{{ PIWIK_SITE_ID }}'

--- a/src/views/partials/piwik.njk
+++ b/src/views/partials/piwik.njk
@@ -4,22 +4,6 @@
 
 <!-- Matomo -->
 <script nonce={{ nonce | dump | safe }}>
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    
-    _paq.push(['enableLinkTracking']);
-    (function () {
-      var u = "//matomo.identity.aws.chdev.org/";
-      _paq.push(['setTrackerUrl', u + 'matomo.php']);
-      _paq.push(['setSiteId', '1']);
-      var d = document,
-        g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0];
-      g.async = true;
-      g.src = u + 'matomo.js';
-      s.parentNode.insertBefore(g, s);
-    })();
-
 //  Matomo automation -- this is to remove all the Matomo calls with the hardcoded analytics texts from the njk pages.
 //  In a situation where Matomo analytics needs a non generic customization, the existing hardcoded Matomo calls are still possible.
     var textOnRadioSelection = "";


### PR DESCRIPTION
Removing unused function call for Matomo analytics.
Ticket:
[IDVA5-1790](https://companieshouse.atlassian.net/browse/IDVA5-1790?atlOrigin=eyJpIjoiYTIyMzYyODQ5OTM4NDYyYmFkNzMyMWUwY2YyN2U3NDEiLCJwIjoiaiJ9)

This is similar to the changes made in the following PR, which goes into more detail of why this is no longer required:
[PR-654](https://github.com/companieshouse/acsp-web/pull/654)

[IDVA5-1790]: https://companieshouse.atlassian.net/browse/IDVA5-1790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ