### PR TITLE
Id doc details optional fields

### DIFF
--- a/locales/cy/id-document-details.json
+++ b/locales/cy/id-document-details.json
@@ -20,12 +20,12 @@
     "ukEuDigitalCardHint": "This is 16 characters long. Welsh",
     "ukForceCardHint": "This needs to be a unique reference or number that is shown on the document. Welsh",
     "ukArmedForceCardHint": "This will have between 6 and 8 characters. Welsh",
-    "photoWorkPermitHint": "This is 9 characters long. Welsh",
+    "photoWorkPermitHint": "This needs to be a unique reference or number that is shown on the document. Welsh",
     "photoimmigrationDocHint": "This is 9 characters long. Welsh",
     "photoVisaHint": "This will have between 8 and 9 characters. Welsh",
     "ukFirearmsLicenceHint": "This will have between 6 and 10 characters. Welsh",
     "photoIdPradoDetailsHint": "This needs to be a unique reference or number that is shown on the document. Welsh",
-
+    "optional": "(if it has one welsh)",
 
     "error-docNumberInput": "Enter the details for the {doc selected} welsh",
     "error-docNumberLength": "{doc selected} must be 50 characters or fewer welsh",

--- a/locales/en/id-document-details.json
+++ b/locales/en/id-document-details.json
@@ -20,12 +20,12 @@
     "ukEuDigitalCardHint": "This is 16 characters long.",
     "ukForceCardHint": "This needs to be a unique reference or number that is shown on the document.",
     "ukArmedForceCardHint": "This will have between 6 and 8 characters.",
-    "photoWorkPermitHint": "This is 9 characters long.",
+    "photoWorkPermitHint": "This needs to be a unique reference or number that is shown on the document.",
     "photoimmigrationDocHint": "This is 9 characters long.",
     "photoVisaHint": "This will have between 8 and 9 characters.",
     "ukFirearmsLicenceHint": "This will have between 6 and 10 characters.",
     "photoIdPradoDetailsHint": "This needs to be a unique reference or number that is shown on the document.",
-
+    "optional": "(if it has one)",
 
     "error-docNumberInput": "Enter the details for the {doc selected}",
     "error-docNumberLength": "{doc selected} must be 50 characters or fewer",

--- a/src/services/idDocumentDetailsService.ts
+++ b/src/services/idDocumentDetailsService.ts
@@ -5,6 +5,7 @@ import { saveDataInSession } from "../utils/sessionHelper";
 import { USER_DATA } from "../utils/constants";
 import { resolveErrorMessage } from "../validations/validation";
 import { FormatService } from "./formatService";
+import { getLocalesService } from "../utils/localise";
 
 export class IdDocumentDetailsService {
     public saveIdDocumentDetails = (req: Request, clientData: ClientData, formattedDocumentsChecked: string[], i18n: any) => {
@@ -47,33 +48,34 @@ export class IdDocumentDetailsService {
             const parts: string[] = element.param.split("_");
             const index = Number(parts[1]);
             const docName = documentsChecked[index - 1];
+            const locales = getLocalesService();
 
-            errorMessage = getErrorForSpecificDocs(docName, errorMessage, errorText, whenIdDocsChecked);
+            errorMessage = getErrorForSpecificDocs(docName, errorMessage, errorText, whenIdDocsChecked, locales.i18nCh.resolveNamespacesKeys(lang));
             // if error message is not empty, replace doc name placeholder
             if (errorMessage !== "") {
                 element.msg = errorMessage.replace("{doc selected}", docName);
                 newErrorArray.push(element);
             }
-        }); 
+        });
         return newErrorArray;
     };
 }
 
-const getErrorForSpecificDocs = (docName:string, errorMessage: string, errorText: string, whenIdDocsChecked:Date) => {
-    // make error message empty for optional fields for below specific docs 
-    if (((docName === "UK accredited PASS card" || docName === "UK HM Armed Forces Veteran Card") && errorText === "noExpiryDate") ||
-        ((docName === "Photographic ID listed on PRADO" || docName === "Photographic work permit (government issued)") && 
-         (errorText === "noExpiryDate"|| errorText === "noCountry" || errorText === "docNumberInput"))) {    
-      return "";
-    // replace date placeholder with formatted date if error is about invalid expirydate 
-    }else if (errorText === "dateAfterIdChecksDone") {
+const getErrorForSpecificDocs = (docName:string, errorMessage: string, errorText: string, whenIdDocsChecked:Date, i18n: any) => {
+    // make error message empty for optional fields for below specific docs
+    if (((docName === i18n.passCard || docName === i18n.ukArmedForceCard) && errorText === "noExpiryDate") ||
+        ((docName === i18n.photoIdPrado || docName === i18n.photoWorkPermit) &&
+         (errorText === "noExpiryDate" || errorText === "noCountry" || errorText === "docNumberInput"))) {
+        return "";
+    // replace date placeholder with formatted date if error is about invalid expirydate
+    } else if (errorText === "dateAfterIdChecksDone") {
         const idChecksCompletedDate = whenIdDocsChecked.getDate() + " " +
                                       whenIdDocsChecked.toLocaleString("default", { month: "long" }) + " " +
                                       whenIdDocsChecked.getFullYear();
-      errorMessage = errorMessage.replace("{id checks completed}", idChecksCompletedDate);
-      return errorMessage;
-    // for non of the above return back error message as it is   
-    }else{
-      return errorMessage;  
+        errorMessage = errorMessage.replace("{id checks completed}", idChecksCompletedDate);
+        return errorMessage;
+    // for non of the above return back error message as it is
+    } else {
+        return errorMessage;
     }
 };

--- a/src/services/idDocumentDetailsService.ts
+++ b/src/services/idDocumentDetailsService.ts
@@ -51,7 +51,7 @@ export class IdDocumentDetailsService {
             errorMessage = getErrorForSpecificDocs(docName, errorMessage, errorText, whenIdDocsChecked);
             // if error message is not empty, replace doc name placeholder
             if (errorMessage !== "") {
-                element.msg = element.msg.replace("{doc selected}", docName);
+                element.msg = errorMessage.replace("{doc selected}", docName);
                 newErrorArray.push(element);
             }
         }); 

--- a/src/views/id-document-details/id-document-details.njk
+++ b/src/views/id-document-details/id-document-details.njk
@@ -5,6 +5,9 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.idDocumentDetailstitle %}
 
+{% set expiryDateOptionalDocs = [i18n.passCard, i18n.ukArmedForceCard, i18n.photoIdPrado, i18n.photoWorkPermit] %}
+{% set otherOptionalDocs = [i18n.photoIdPrado, i18n.photoWorkPermit] %}
+
 {% block main_content %}
   <form action="" method="POST">
     {% include "partials/csrf_token.njk" %}
@@ -12,10 +15,16 @@
     {% for body in documentsChecked %}
       {% set index = loop.index %}
         <h2 class="govuk-heading-m"> {{body}} {{i18n.detailsMessage}} </h2>
+
         <!--Document Input-->
+        {% if otherOptionalDocs.includes(body) %}
+           {% set labelText = body + i18n.number + " " +  i18n.optional %}
+        {% else %}
+           {% set labelText = body + i18n.number %}
+        {% endif %}
         {{ govukInput({
             label: {
-                text: body + i18n.number,
+                text: labelText,
                 classes: "govuk-label "
             },
             classes: "govuk-input--width-10",
@@ -36,7 +45,13 @@
         <!--Country  Input-->
         <div id="typeahead-form-group-{{index}}" class="govuk-form-group
           {% if errors["countryInput_" + index] %} govuk-form-group--error{% endif %}">
-            <label class="govuk-label" for="location">{{i18n.chooseCountryText}} </label>
+            <label class="govuk-label" for="location">
+              {% if otherOptionalDocs.includes(body) %}
+                {{i18n.chooseCountryText}} {{i18n.optional}}
+              {% else %}
+                {{i18n.chooseCountryText}} 
+              {% endif %}
+            </label>
             <p class="govuk-hint" id="typeahead-hint-{{index}}">{{i18n.chooseCountryhint}} {{body}}.</p>
             {% set dropdownDefaultText = i18n.chooseCountryText1 %}
             {% set dropdownValue = payload["countryInput_" + index] %}

--- a/src/views/partials/date.njk
+++ b/src/views/partials/date.njk
@@ -14,7 +14,11 @@
    <div class="govuk-form-group {% if errorMessageText  %}govuk-form-group--error{% endif %}">
     <fieldset class="govuk-fieldset" role="group" aria-describedby="passport-issued-hint">
         <legend class="govuk-fieldset__legend">
-           {{i18n.ExpiryDate}}
+           {% if expiryDateOptionalDocs.includes(body) %}
+              {{ i18n.ExpiryDate }} {{ i18n.optional }}
+           {% else %}
+              {{ i18n.ExpiryDate }}
+           {% endif %}
         </legend>
         <div id="passport-issued-hint" class="govuk-hint">
            {{i18n.ExpiryDateHint}}

--- a/test/src/services/idDocumentDetailsService.test.ts
+++ b/test/src/services/idDocumentDetailsService.test.ts
@@ -118,3 +118,33 @@ describe("IdDocumentDetailsService tests", () => {
         expect(actual[0].msg).toBe(expected[0].msg);
     });
 });
+
+describe("errorListDisplay for PRADO", () => {
+    const service = new IdDocumentDetailsService();
+    test.each([
+        [
+            [{ msg: "noExpiryDate", param: "expiryDateDay_1" }],
+            ["Photographic ID listed on PRADO"],
+            new Date(2025, 2, 28),
+            0
+        ],
+        [
+            [{ msg: "noCountry", param: "countryInput_1" }],
+            ["Photographic ID listed on PRADO"],
+            new Date(2025, 2, 28),
+            0
+        ],
+        [
+            [{ msg: "docNumberInput", param: "documentNumber_1" }],
+            ["Photographic ID listed on PRADO"],
+            new Date(2025, 2, 28),
+            0
+        ]
+    ])(
+        "should not return an error array for non-mandatory fields for PRADO",
+        (errors, documentsChecked, whenIdDocsChecked, expectedLength) => {
+            const actual = service.errorListDisplay(errors, documentsChecked, "en", whenIdDocsChecked);
+            expect(actual.length).toBe(expectedLength);
+        }
+    );
+});


### PR DESCRIPTION
- The views are modified to conditionally add "(if it has one)" text for non mandatory fields for specific docs
- The service is modified:
               to not have error message for optional fields for specific docs.
               to construct proper error message. i.e replace placeholders with correct text

For documents, passCard and ukArmedForceCard - expiry date is optional
For documents, photoIdPrado and photoWorkPermit - all three fields (doc number, expiry date and country) are optional



