### PR TITLE
Remove {NAME} from tab titles

### DIFF
--- a/src/views/personal-code/personal-code.njk
+++ b/src/views/personal-code/personal-code.njk
@@ -1,11 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% extends "layouts/default.njk" %}
 
-{% if "en" in lang %}
-    {% set title =  i18n.codePageHeading | replace('{NAME}', firstName + ' ' + lastName) %}
-{% else %}
-    {% set title = (i18n.codePageHeading + ' ' + firstName + ' ' + lastName) | replace('{NAME}', '') %}
-{% endif %}
+{% set title =  i18n.codePageHeading | replace('{NAME}', firstName + ' ' + lastName) %}
 
 {% block main_content %}
     <form action="" method="POST">

--- a/src/views/personal-code/personal-code.njk
+++ b/src/views/personal-code/personal-code.njk
@@ -2,9 +2,9 @@
 {% extends "layouts/default.njk" %}
 
 {% if "en" in lang %}
-    {% set title =  firstName + ' ' + lastName + ' ' + i18n.codePageTitle  %}
+    {% set title =  i18n.codePageHeading | replace('{NAME}', firstName + ' ' + lastName) %}
 {% else %}
-    {% set title = i18n.codePageTitle + ' ' + firstName + ' ' + lastName %}
+    {% set title = (i18n.codePageHeading + ' ' + firstName + ' ' + lastName) | replace('{NAME}', '') %}
 {% endif %}
 
 {% block main_content %}

--- a/src/views/persons-email/persons-email.njk
+++ b/src/views/persons-email/persons-email.njk
@@ -4,9 +4,9 @@
 {% extends "layouts/default.njk" %}
 
 {% if "en" in lang %}
-    {% set title = i18n.whatIs + ' ' + firstName + ' ' + lastName + i18n.emailAddress %}
+    {% set title = i18n.whatIs + i18n.emailAddress | replace('{NAME}', firstName + ' ' + lastName) %}
 {% else %}
-    {% set title = i18n.whatIs + ' ' + i18n.emailAddress + ' ' + firstName + ' ' + lastName %}
+    {% set title = (i18n.whatIs + ' ' + i18n.emailAddress + ' ' + firstName + ' ' + lastName) | replace('{NAME}', '') %}
 {% endif %}
 
 {% block main_content %}

--- a/src/views/persons-email/persons-email.njk
+++ b/src/views/persons-email/persons-email.njk
@@ -3,11 +3,7 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% extends "layouts/default.njk" %}
 
-{% if "en" in lang %}
-    {% set title = i18n.whatIs + i18n.emailAddress | replace('{NAME}', firstName + ' ' + lastName) %}
-{% else %}
-    {% set title = (i18n.whatIs + ' ' + i18n.emailAddress + ' ' + firstName + ' ' + lastName) | replace('{NAME}', '') %}
-{% endif %}
+{% set title = i18n.whatIs + i18n.emailAddress | replace('{NAME}', firstName + ' ' + lastName) %}
 
 {% block main_content %}
     <form action="" method="POST">


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1855

For email address and personal code screens, string "{NAME}" was showing in the tab titles which was added as part of Matomo changes. I've used same approach to replace this in tab title as we do in page header. ~~For Welsh the word order is slightly different so I am removing this string completely so that the name can appear at the end~~

I removed the en/cy check as this is no longer needed since we are setting the word order correctly in locales files