### PR TITLE
Moving the error handling above unhandled errors, allowing it to be called

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -82,14 +82,14 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 // Channel all requests through router dispatch
 routerDispatch(app);
 
+app.use(...errorHandler);
+
 // Unhandled errors
 app.use((err: any, req: Request, res: Response, next: NextFunction) => {
     logger.error(`${err.name} - appError: ${err.message} - ${err.stack}`);
     const errorService = new ErrorService();
     errorService.renderErrorPage(res, getLocalesService(), selectLang(req.query.lang), req.url);
 });
-
-app.use(...errorHandler);
 
 // Unhandled exceptions
 process.on("uncaughtException", (err: any) => {


### PR DESCRIPTION
Moving the error handling above unhandled errors, allowing it to be called

Previously the error handling was never able to be called as all errors would be caught by the unhandled errors function. This is because JS executes code from top to bottom.