### PR TITLE
Verify client - Data getting cleared for ID Details screen on clickin…

### DIFF
--- a/src/controllers/idDocumentDetailsController.ts
+++ b/src/controllers/idDocumentDetailsController.ts
@@ -30,7 +30,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     );
     let payload;
     if (clientData.idDocumentDetails != null) {
-        payload = createPayload(clientData.idDocumentDetails, formattedDocumentsChecked);
+        payload = createPayload(clientData.idDocumentDetails, formattedDocumentsChecked, locales.i18nCh.resolveNamespacesKeys(lang));
     }
 
     res.render(config.ID_DOCUMENT_DETAILS, {
@@ -94,11 +94,12 @@ const getBackUrl = (selectedOption: string) => {
     }
 };
 
-export const createPayload = (idDocumentDetails: DocumentDetails[], formatDocumentsCheckedText: string[]): { [key: string]: string | undefined } => {
+export const createPayload = (idDocumentDetails: DocumentDetails[], formatDocumentsCheckedText: string[], i18:any): { [key: string]: string | undefined } => {
     const payload: { [key: string]: any | undefined } = {};
     idDocumentDetails.forEach((body, index) => {
         for (let i = 0; i < formatDocumentsCheckedText.length; i++) {
-            if (formatDocumentsCheckedText[i] === body.docName) {
+            // eslint-disable-next-line
+            if (formatDocumentsCheckedText[i] === body.docName, i18) {
                 payload[`documentNumber_${i + 1}`] = body.documentNumber;
                 if (body.expiryDate) {
                     payload[`expiryDateDay_${i + 1}`] = body.expiryDate!.getDate();

--- a/test/src/controllers/idDocumentDetailsController.test.ts
+++ b/test/src/controllers/idDocumentDetailsController.test.ts
@@ -83,7 +83,7 @@ describe("createPayload tests", () => {
         ];
         const formatDocumentsCheckedText = ["UK accredited PASS card"];
 
-        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText);
+        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText, "en");
 
         expect(result).toEqual({
             documentNumber_1: "12345678",
@@ -105,7 +105,7 @@ describe("createPayload tests", () => {
         ];
         const formatDocumentsCheckedText = ["UK HM Armed Forces Veteran Card"];
 
-        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText);
+        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText, "en");
 
         expect(result).toEqual({
             documentNumber_1: "12345678",
@@ -127,7 +127,7 @@ describe("createPayload tests", () => {
         ];
         const formatDocumentsCheckedText = ["Irish passport card"];
 
-        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText);
+        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText, "en");
 
         expect(result).toEqual({
             documentNumber_1: "12345678",


### PR DESCRIPTION
Fix for the empty fields of the id documents details page.

