### PR TITLE
Conditional check added for change links for Group B docs

### DIFF
--- a/src/views/check-your-answers/check-your-answers.njk
+++ b/src/views/check-your-answers/check-your-answers.njk
@@ -252,7 +252,7 @@
                 href: "/tell-companies-house-you-have-verified-someones-identity/id-document-details" + "?lang=" + lang + "#documentNumber_" + loop.index,
                 text: i18n.checkAnswerDetailsChange,
                 visuallyHiddenText: i18n.number | replace("{DOCNAME}", doc.docName)
-              }
+              } if doc.documentNumber != i18n.dateNotProvided
             ]
           }
         },
@@ -269,7 +269,7 @@
                 href: "/tell-companies-house-you-have-verified-someones-identity/id-document-details" + "?lang=" + lang + "#expiryDateDay_" + loop.index,
                 text: i18n.checkAnswerDetailsChange,
                 visuallyHiddenText: i18n.ExpiryDate
-              }
+              } if doc.formattedExpiryDate != i18n.dateNotProvided
             ]
           }
         },
@@ -286,7 +286,7 @@
                 href: "/tell-companies-house-you-have-verified-someones-identity/id-document-details" + "?lang=" + lang + "#countryInput_" + loop.index,
                 text: i18n.checkAnswerDetailsChange,
                 visuallyHiddenText: i18n.chooseCountryText
-              }
+              } if doc.countryOfIssue != i18n.dateNotProvided
             ]
           }
         }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1938

- For Group B documents we don't ask for any details which show as 'Not provided' on Check Your Answers screen. This bug was to hide the 'Change' links for these Group B documents.
- I added a conditional check for the document number, expiry date and country of issue so that the change link action would only render if those values were provided. For fields with no values, the idDocumentDetailsService is defaulting them to the string 'Not provided'.

![image](https://github.com/user-attachments/assets/653bd61e-73f6-42d7-a779-1b9939997e9b)
