### PR TITLE
Filter Option 2 Group B documents to hide on check your answers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -241,25 +241,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
-      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
-      "integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.8"
+        "@babel/types": "^7.26.10"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -491,9 +493,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -502,14 +505,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.8.tgz",
-      "integrity": "sha512-iNKaX3ZebKIsCvJ+0jd6embf+Aulaa3vNBqZ41kM7iTWjx5qzWKXGHiJUW3+nTpQ18SG11hdF8OAzKrpXkb96Q==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.8",
-        "@babel/types": "^7.26.8"
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -543,10 +547,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
-      "integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -3196,9 +3201,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -13943,22 +13949,22 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
-      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10"
       }
     },
     "@babel/parser": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
-      "integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.26.8"
+        "@babel/types": "^7.26.10"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -14115,22 +14121,22 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.8.tgz",
-      "integrity": "sha512-iNKaX3ZebKIsCvJ+0jd6embf+Aulaa3vNBqZ41kM7iTWjx5qzWKXGHiJUW3+nTpQ18SG11hdF8OAzKrpXkb96Q==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.8",
-        "@babel/types": "^7.26.8"
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       }
     },
     "@babel/traverse": {
@@ -14157,9 +14163,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
-      "integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -16144,9 +16150,9 @@
       }
     },
     "axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/src/controllers/checkYourAnswers.ts
+++ b/src/controllers/checkYourAnswers.ts
@@ -47,10 +47,12 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
     const identityDocuments = clientData.idDocumentDetails!;
 
-    const formattedIdentityDocuments = identityDocuments.map((doc) => ({
-        ...doc,
-        docName: FormatService.findDocumentName(doc.docName, locales.i18nCh.resolveNamespacesKeys(lang))
-    }));
+    const formattedIdentityDocuments = identityDocuments
+        .map((doc) => ({
+            ...doc,
+            docName: FormatService.findDocumentName(doc.docName, locales.i18nCh.resolveNamespacesKeys(lang), clientData.howIdentityDocsChecked)
+        }))
+        .filter((doc) => doc.docName !== "");
 
     const amlBodies = getAmlBodiesAsString(acspDetails);
 
@@ -101,10 +103,12 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const amlBodies = getAmlBodiesAsString(acspDetails);
         const identityDocuments = clientData.idDocumentDetails!;
 
-        const formattedIdentityDocuments = identityDocuments.map((doc) => ({
-            ...doc,
-            docName: FormatService.findDocumentName(doc.docName, locales.i18nCh.resolveNamespacesKeys(lang))
-        }));
+        const formattedIdentityDocuments = identityDocuments
+            .map((doc) => ({
+                ...doc,
+                docName: FormatService.findDocumentName(doc.docName, locales.i18nCh.resolveNamespacesKeys(lang), clientData.howIdentityDocsChecked)
+            }))
+            .filter((doc) => doc.docName !== "");
 
         const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
         res.status(400).render(config.CHECK_YOUR_ANSWERS, {

--- a/src/controllers/idDocumentDetailsController.ts
+++ b/src/controllers/idDocumentDetailsController.ts
@@ -30,7 +30,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     );
     let payload;
     if (clientData.idDocumentDetails != null) {
-        payload = createPayload(clientData.idDocumentDetails, formattedDocumentsChecked, locales.i18nCh.resolveNamespacesKeys(lang));
+        payload = createPayload(clientData.idDocumentDetails, formattedDocumentsChecked, locales.i18nCh.resolveNamespacesKeys(lang), clientData.howIdentityDocsChecked!);
     }
 
     res.render(config.ID_DOCUMENT_DETAILS, {
@@ -94,11 +94,11 @@ const getBackUrl = (selectedOption: string) => {
     }
 };
 
-export const createPayload = (idDocumentDetails: DocumentDetails[], formatDocumentsCheckedText: string[], i18: any): { [key: string]: string | undefined } => {
+export const createPayload = (idDocumentDetails: DocumentDetails[], formatDocumentsCheckedText: string[], i18: any, howIdentityDocsChecked: string): { [key: string]: string | undefined } => {
     const payload: { [key: string]: any | undefined } = {};
     idDocumentDetails.forEach((body, index) => {
         for (let i = 0; i < formatDocumentsCheckedText.length; i++) {
-            if (formatDocumentsCheckedText[i] === FormatService.findDocumentName(body.docName, i18)) {
+            if (formatDocumentsCheckedText[i] === FormatService.findDocumentName(body.docName, i18, howIdentityDocsChecked)) {
                 payload[`documentNumber_${i + 1}`] = body.documentNumber;
                 if (body.expiryDate) {
                     payload[`expiryDateDay_${i + 1}`] = body.expiryDate!.getDate();

--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -59,13 +59,43 @@ export class FormatService {
     public static formatDocumentsChecked (
         documents: string[] | undefined,
         i18n: any
+
     ): string {
         if (!documents || documents.length === 0) {
             return "";
         }
+        const documentMapping: { [key: string]: string } = {
+            passport: i18n.biometricPassport,
+            irish_passport_card: i18n.irishPassport,
+            UK_or_EU_driving_licence: i18n.ukDriversLicence,
+            EEA_identity_card: i18n.identityCard,
+            UK_biometric_residence_permit: i18n.biometricPermit,
+            UK_biometric_residence_card: i18n.biometricCard,
+            UK_frontier_worker_permit: i18n.frontierPermit,
+
+            UK_PASS_card: i18n.passCard,
+            UK_or_EU_digital_tachograph_card: i18n.ukEuDigitalCard,
+            UK_HM_forces_card: i18n.ukForceCard,
+            UK_HM_veteran_card: i18n.ukArmedForceCard,
+            work_permit_photo_id: i18n.photoWorkPermit,
+            immigration_document_photo_id: i18n.photoimmigrationDoc,
+            visa_photo_id: i18n.photoVisa,
+            UK_firearms_licence: i18n.ukFirearmsLicence,
+            PRADO_supported_photo_id: i18n.photoIdPrado,
+            birth_certificate: i18n.birthCert,
+            marriage_certificate: i18n.marriageCert,
+            immigration_document_non_photo_id: i18n.noPhotoimmigrationDoc,
+            visa_non_photo_id: i18n.noPhotoVisa,
+            work_permit_non_photo_id: i18n.noPhotoWorkPermit,
+            bank_statement: i18n.bankStatement,
+            rental_agreement: i18n.rentalAgreement,
+            mortgage_statement: i18n.morgageStatement,
+            UK_council_tax_statement: i18n.taxStatement,
+            utility_bill: i18n.utilityBill
+        };
 
         const formattedDocuments = documents.map((doc) => {
-            const docText = FormatService.getDocumentName(doc, i18n);
+            const docText = documentMapping[doc] || doc;
             return `• ${docText}`;
         });
 
@@ -169,43 +199,44 @@ export class FormatService {
 
     public static findDocumentName (
         document: string | undefined,
-        i18n: any
+        i18n: any,
+        howIdentityDocsChecked: string | undefined
     ): string {
         if (!document || document.length === 0) {
             return "";
         }
-        return FormatService.getDocumentName(document, i18n);
-    }
+        let documentMapping: { [key: string]: string };
 
-    private static getDocumentName (document: string, i18n: any): string {
-        const documentMapping: { [key: string]: string } = {
-            passport: i18n.biometricPassport,
-            irish_passport_card: i18n.irishPassport,
-            UK_or_EU_driving_licence: i18n.ukDriversLicence,
-            EEA_identity_card: i18n.identityCard,
-            UK_biometric_residence_permit: i18n.biometricPermit,
-            UK_biometric_residence_card: i18n.biometricCard,
-            UK_frontier_worker_permit: i18n.frontierPermit,
-            UK_PASS_card: i18n.passCard,
-            UK_or_EU_digital_tachograph_card: i18n.ukEuDigitalCard,
-            UK_HM_forces_card: i18n.ukForceCard,
-            UK_HM_veteran_card: i18n.ukArmedForceCard,
-            work_permit_photo_id: i18n.photoWorkPermit,
-            immigration_document_photo_id: i18n.photoimmigrationDoc,
-            visa_photo_id: i18n.photoVisa,
-            UK_firearms_licence: i18n.ukFirearmsLicence,
-            PRADO_supported_photo_id: i18n.photoIdPrado,
-            birth_certificate: i18n.birthCert,
-            marriage_certificate: i18n.marriageCert,
-            immigration_document_non_photo_id: i18n.noPhotoimmigrationDoc,
-            visa_non_photo_id: i18n.noPhotoVisa,
-            work_permit_non_photo_id: i18n.noPhotoWorkPermit,
-            bank_statement: i18n.bankStatement,
-            rental_agreement: i18n.rentalAgreement,
-            mortgage_statement: i18n.morgageStatement,
-            UK_council_tax_statement: i18n.taxStatement,
-            utility_bill: i18n.utilityBill
-        };
-        return documentMapping[document] ? documentMapping[document] : document;
+        if (howIdentityDocsChecked === "cryptographic_security_features_checked") {
+            documentMapping = {
+                passport: i18n.biometricPassport,
+                irish_passport_card: i18n.irishPassport,
+                UK_or_EU_driving_licence: i18n.ukDriversLicence,
+                EEA_identity_card: i18n.identityCard,
+                UK_biometric_residence_permit: i18n.biometricPermit,
+                UK_biometric_residence_card: i18n.biometricCard,
+                UK_frontier_worker_permit: i18n.frontierPermit
+            };
+        } else {
+            documentMapping = {
+                passport: i18n.passport,
+                irish_passport_card: i18n.IrishCard,
+                EEA_identity_card: i18n.identityCard,
+                UK_biometric_residence_permit: i18n.ukBRP,
+                UK_biometric_residence_card: i18n.ukBRC,
+                UK_PASS_card: i18n.passCard,
+                UK_or_EU_digital_tachograph_card: i18n.ukEuDigitalCard,
+                UK_or_EU_driving_licence: i18n.fullDrivingLicense,
+                UK_HM_forces_card: i18n.ukForceCard,
+                UK_HM_veteran_card: i18n.ukArmedForceCard,
+                UK_frontier_worker_permit: i18n.ukFrontierPermit,
+                work_permit_photo_id: i18n.photoWorkPermit,
+                immigration_document_photo_id: i18n.photoimmigrationDoc,
+                visa_photo_id: i18n.photoVisa,
+                UK_firearms_licence: i18n.ukFirearmsLicence,
+                PRADO_supported_photo_id: i18n.photoIdPrado
+            };
+        }
+        return documentMapping[document] || "";
     }
 }

--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -202,6 +202,7 @@ export class FormatService {
         i18n: any,
         howIdentityDocsChecked: string | undefined
     ): string {
+
         if (!document || document.length === 0) {
             return "";
         }

--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -111,39 +111,8 @@ export class FormatService {
         if (!documents || documents.length === 0) {
             return formattedDocuments;
         }
-        let documentMapping:{ [key: string]: string };
-        if (howIdentityDocsChecked === "cryptographic_security_features_checked") {
-            // option1
-            documentMapping = {
-                passport: i18n.biometricPassport,
-                irish_passport_card: i18n.irishPassport,
-                UK_or_EU_driving_licence: i18n.ukDriversLicence,
-                EEA_identity_card: i18n.identityCard,
-                UK_biometric_residence_permit: i18n.biometricPermit,
-                UK_biometric_residence_card: i18n.biometricCard,
-                UK_frontier_worker_permit: i18n.frontierPermit
-            };
-        } else {
-            // option2 groupA docs
-            documentMapping = {
-                passport: i18n.passport,
-                irish_passport_card: i18n.IrishCard,
-                EEA_identity_card: i18n.identityCard,
-                UK_biometric_residence_permit: i18n.ukBRP,
-                UK_biometric_residence_card: i18n.ukBRC,
-                UK_PASS_card: i18n.passCard,
-                UK_or_EU_digital_tachograph_card: i18n.ukEuDigitalCard,
-                UK_or_EU_driving_licence: i18n.fullDrivingLicense,
-                UK_HM_forces_card: i18n.ukForceCard,
-                UK_HM_veteran_card: i18n.ukArmedForceCard,
-                UK_frontier_worker_permit: i18n.ukFrontierPermit,
-                work_permit_photo_id: i18n.photoWorkPermit,
-                immigration_document_photo_id: i18n.photoimmigrationDoc,
-                visa_photo_id: i18n.photoVisa,
-                UK_firearms_licence: i18n.ukFirearmsLicence,
-                PRADO_supported_photo_id: i18n.photoIdPrado
-            };
-        }
+        const documentMapping = FormatService.getDocumentMapping(howIdentityDocsChecked, i18n);
+
         documents.forEach((doc) => {
             if (documentMapping[doc]) {
                 formattedDocuments.push(documentMapping[doc]);
@@ -202,14 +171,16 @@ export class FormatService {
         i18n: any,
         howIdentityDocsChecked: string | undefined
     ): string {
-
         if (!document || document.length === 0) {
             return "";
         }
-        let documentMapping: { [key: string]: string };
+        const documentMapping = FormatService.getDocumentMapping(howIdentityDocsChecked, i18n);
+        return documentMapping[document] || "";
+    }
 
+    private static getDocumentMapping (howIdentityDocsChecked: string | undefined, i18n: any): { [key: string]: string } {
         if (howIdentityDocsChecked === "cryptographic_security_features_checked") {
-            documentMapping = {
+            return {
                 passport: i18n.biometricPassport,
                 irish_passport_card: i18n.irishPassport,
                 UK_or_EU_driving_licence: i18n.ukDriversLicence,
@@ -219,7 +190,7 @@ export class FormatService {
                 UK_frontier_worker_permit: i18n.frontierPermit
             };
         } else {
-            documentMapping = {
+            return {
                 passport: i18n.passport,
                 irish_passport_card: i18n.IrishCard,
                 EEA_identity_card: i18n.identityCard,
@@ -238,6 +209,5 @@ export class FormatService {
                 PRADO_supported_photo_id: i18n.photoIdPrado
             };
         }
-        return documentMapping[document] || "";
     }
 }

--- a/test/src/controllers/idDocumentDetailsController.test.ts
+++ b/test/src/controllers/idDocumentDetailsController.test.ts
@@ -76,7 +76,7 @@ describe("createPayload tests", () => {
     it("should handle UK accredited PASS card identity document with optional expiryDate correctly", () => {
         const idDocumentDetails = [
             {
-                docName: "UK accredited PASS card",
+                docName: "UK_PASS_card",
                 documentNumber: "12345678",
                 expiryDate: undefined,
                 countryOfIssue: "United Kingdom"
@@ -84,8 +84,9 @@ describe("createPayload tests", () => {
         ];
         const formatDocumentsCheckedText = ["UK accredited PASS card"];
         const i18n = { passCard: "UK accredited PASS card" };
+        const howIdentityDocsChecked = "physical_security_features_checked";
 
-        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText, i18n);
+        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText, i18n, howIdentityDocsChecked);
 
         expect(result).toEqual({
             documentNumber_1: "12345678",
@@ -99,7 +100,7 @@ describe("createPayload tests", () => {
     it("should handle UK HM Armed Forces Veteran Card identity document with optional expiryDate correctly", () => {
         const idDocumentDetails = [
             {
-                docName: "UK HM Armed Forces Veteran Card",
+                docName: "UK_HM_veteran_card",
                 documentNumber: "12345678",
                 expiryDate: undefined,
                 countryOfIssue: "United Kingdom"
@@ -107,8 +108,9 @@ describe("createPayload tests", () => {
         ];
         const formatDocumentsCheckedText = ["UK HM Armed Forces Veteran Card"];
         const i18n = { ukArmedForceCard: "UK HM Armed Forces Veteran Card" };
+        const howIdentityDocsChecked = "physical_security_features_checked";
 
-        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText, i18n);
+        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText, i18n, howIdentityDocsChecked);
 
         expect(result).toEqual({
             documentNumber_1: "12345678",
@@ -122,7 +124,7 @@ describe("createPayload tests", () => {
     it("should construct payload correctly when expiryDate is provided", () => {
         const idDocumentDetails = [
             {
-                docName: "Irish passport card",
+                docName: "irish_passport_card",
                 documentNumber: "12345678",
                 expiryDate: new Date(2030, 9, 10),
                 countryOfIssue: "Ireland"
@@ -130,8 +132,9 @@ describe("createPayload tests", () => {
         ];
         const formatDocumentsCheckedText = ["Irish passport card"];
         const i18n = { irishPassport: "Irish passport card" };
+        const howIdentityDocsChecked = "cryptographic_security_features_checked";
 
-        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText, i18n);
+        const result = createPayload(idDocumentDetails, formatDocumentsCheckedText, i18n, howIdentityDocsChecked);
 
         expect(result).toEqual({
             documentNumber_1: "12345678",

--- a/test/src/services/formatService.test.ts
+++ b/test/src/services/formatService.test.ts
@@ -32,28 +32,42 @@ describe("Format Service tests", () => {
         it("should return the document name for option 1 doc", () => {
             const document = "irish_passport_card";
             const i18n = {
-                irishPassport: "Irish Passport"
+                irishPassport: "Irish passport card"
             };
+            const howIdentityDocsChecked = "cryptographic_security_features_checked";
 
-            const docName = FormatService.findDocumentName(document, i18n);
-            expect(docName).toStrictEqual("Irish Passport");
+            const docName = FormatService.findDocumentName(document, i18n, howIdentityDocsChecked);
+            expect(docName).toStrictEqual("Irish passport card");
         });
 
-        it("should return the document name for option 2 doc", () => {
+        it("should return the document name for option 2 doc Group A", () => {
             const document = "visa_photo_id";
             const i18n = {
                 photoVisa: "Photo Visa"
             };
+            const howIdentityDocsChecked = "physical_security_features_checked";
 
-            const docName = FormatService.findDocumentName(document, i18n);
+            const docName = FormatService.findDocumentName(document, i18n, howIdentityDocsChecked);
             expect(docName).toStrictEqual("Photo Visa");
         });
 
-        it("should return empty string for no document", () => {
+        it("should return empty string for option 2 doc Group B", () => {
+            const document = "utility_bill";
+            const i18n = {
+                utilityBill: "Utility bill (for the person’s current address)"
+            };
+            const howIdentityDocsChecked = "physical_security_features_checked";
+
+            const docName = FormatService.findDocumentName(document, i18n, howIdentityDocsChecked);
+            expect(docName).toStrictEqual("");
+        });
+
+        it("should return empty string for no document Option 1", () => {
             const document = undefined;
             const i18n = {};
+            const howIdentityDocsChecked = "cryptographic_security_features_checked";
 
-            const docName = FormatService.findDocumentName(document, i18n);
+            const docName = FormatService.findDocumentName(document, i18n, howIdentityDocsChecked);
             expect(docName).toStrictEqual("");
         });
     });


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1938

- If Option 2 is selected, only the Group A document details should be shown on Check Your Answers. Group B documents should not be shown.

- I added an if check to the findDocumentName mapping to check for Option 1 or 2 and only map Option 1 and Option 2 Group A documents. Group B docs will return an empty string and these are filtered out of the formattedIdentityDocuments array used in the CheckYourAnswers.njk to loop through and display the rows per document

![image](https://github.com/user-attachments/assets/e27431bc-1722-4009-ae9d-2939121fe182)
![image](https://github.com/user-attachments/assets/7eced4f1-d989-460c-96e4-ea3e4c6d8877)