### PR TITLE
Adding visually hidden span with document name in on id document details page

### DIFF
--- a/src/views/id-document-details/id-document-details.njk
+++ b/src/views/id-document-details/id-document-details.njk
@@ -46,6 +46,7 @@
         <div id="typeahead-form-group-{{index}}" class="govuk-form-group
           {% if errors["countryInput_" + index] %} govuk-form-group--error{% endif %}">
             <label class="govuk-label" for="location">
+              <span class="govuk-visually-hidden">{{ body }}</span>
               {% if otherOptionalDocs.includes(body) %}
                 {{i18n.chooseCountryText}} {{i18n.optional}}
               {% else %}

--- a/src/views/partials/date.njk
+++ b/src/views/partials/date.njk
@@ -14,6 +14,7 @@
    <div class="govuk-form-group {% if errorMessageText  %}govuk-form-group--error{% endif %}">
     <fieldset class="govuk-fieldset" role="group" aria-describedby="passport-issued-hint">
         <legend class="govuk-fieldset__legend">
+            <span class="govuk-visually-hidden">{{ body }}</span>
            {% if expiryDateOptionalDocs.includes(body) %}
               {{ i18n.ExpiryDate }} {{ i18n.optional }}
            {% else %}


### PR DESCRIPTION
Adding visually hidden span with document name inside on id document details page. This allows screen reader users to know which expiry date and country of issue field they are on.