### PR TITLE
fixing display bug for Not provided text on check your answers screen

### DIFF
--- a/locales/cy/check-your-answers.json
+++ b/locales/cy/check-your-answers.json
@@ -9,6 +9,6 @@
     "details": "manylion",
     "number": "rhif",
     "confirmSend": "Cadarnhau ac anfon",
-    "dateNotProvided": "Heb ei ddarparu",
+    "notProvided": "Heb ei ddarparu",
     "error-checkYourAnswerEmpty":"Dewiswch i gadarnhau'r datganiad"
 }

--- a/locales/en/check-your-answers.json
+++ b/locales/en/check-your-answers.json
@@ -9,6 +9,6 @@
     "details": "details",
     "number": "number",
     "confirmSend": "Confirm and send",
-    "dateNotProvided": "Not provided",
+    "notProvided": "Not provided",
     "error-checkYourAnswerEmpty":"Select to confirm the declaration"
 }

--- a/src/controllers/idDocumentDetailsController.ts
+++ b/src/controllers/idDocumentDetailsController.ts
@@ -75,7 +75,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             countryList: countryList
         });
     } else {
-        documentDetailsService.saveIdDocumentDetails(req, clientData, clientData.documentsChecked!, locales.i18nCh.resolveNamespacesKeys(lang));
+        documentDetailsService.saveIdDocumentDetails(req, clientData, clientData.documentsChecked!);
         const checkYourAnswersFlag = session?.getExtraData(CHECK_YOUR_ANSWERS_FLAG);
 
         if (checkYourAnswersFlag) {

--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -41,9 +41,9 @@ export class FormatService {
         return parts.join("<br>");
     }
 
-    public static formatDate (date?: Date, i18n?: any): string {
+    public static formatDate (date?: Date): string {
         if (!date) {
-            return i18n ? i18n.dateNotProvided : "";
+            return "";
         }
         if (!(date instanceof Date) || isNaN(date.getTime())) {
             throw new Error("Invalid date");

--- a/src/services/idDocumentDetailsService.ts
+++ b/src/services/idDocumentDetailsService.ts
@@ -8,7 +8,7 @@ import { FormatService } from "./formatService";
 import { getLocalesService } from "../utils/localise";
 
 export class IdDocumentDetailsService {
-    public saveIdDocumentDetails = (req: Request, clientData: ClientData, formattedDocumentsChecked: string[], i18n: any) => {
+    public saveIdDocumentDetails = (req: Request, clientData: ClientData, formattedDocumentsChecked: string[]) => {
         const documentDetails: DocumentDetails[] = [];
         clientData.idDocumentDetails = documentDetails;
         for (let i = 0; i < formattedDocumentsChecked.length; i++) {
@@ -27,11 +27,11 @@ export class IdDocumentDetailsService {
                 );
             }
             documentDetails.push({
-                documentNumber: req.body[docNumberId] ? req.body[docNumberId] : i18n.dateNotProvided,
+                documentNumber: req.body[docNumberId] ? req.body[docNumberId] : "",
                 expiryDate: expiryDate,
-                countryOfIssue: req.body[countryOfIssueId] ? req.body[countryOfIssueId] : i18n.dateNotProvided,
+                countryOfIssue: req.body[countryOfIssueId] ? req.body[countryOfIssueId] : "",
                 docName: formattedDocumentsChecked[i],
-                formattedExpiryDate: FormatService.formatDate(expiryDate, i18n)
+                formattedExpiryDate: FormatService.formatDate(expiryDate)
             });
         }
         if (clientData) {

--- a/src/views/check-your-answers/check-your-answers.njk
+++ b/src/views/check-your-answers/check-your-answers.njk
@@ -238,6 +238,9 @@
 
   {% for doc in clientData.idDocumentDetails %}
   {% if not (groupBDocs.includes(i18n[doc.docName])) %}
+  {% set docNumber = doc.documentNumber if doc.documentNumber else i18n.notProvided %}
+  {% set expiryDate = doc.formattedExpiryDate if doc.formattedExpiryDate else i18n.notProvided %}
+  {% set countryOfIssue = doc.countryOfIssue if doc.countryOfIssue else i18n.notProvided %}
   <h2 class="govuk-heading-m">{{ i18n.details | replace("{DOCNAME}", i18n[doc.docName]) }}</h2>
     {{ govukSummaryList({
       classes: 'govuk-!-margin-bottom-9',
@@ -247,7 +250,7 @@
             text: i18n.number | replace("{DOCNAME}", i18n[doc.docName])
           },
           value: {
-            text: doc.documentNumber
+            text: docNumber
           },
           actions: {
             items: [
@@ -264,7 +267,7 @@
             text: i18n.ExpiryDate
           },
           value: {
-            text: doc.formattedExpiryDate
+            text: expiryDate
           },
           actions: {
             items: [
@@ -281,7 +284,7 @@
             text: i18n.chooseCountryText
           },
           value: {
-            text: doc.countryOfIssue
+            text: countryOfIssue
           },
           actions: {
             items: [

--- a/src/views/confirmation/confirmation.njk
+++ b/src/views/confirmation/confirmation.njk
@@ -159,6 +159,9 @@
   }) }}
   {% for doc in clientData.idDocumentDetails %}
   {% if not (groupBDocs.includes(i18n[doc.docName])) %}
+  {% set docNumber = doc.documentNumber if doc.documentNumber else i18n.notProvided %}
+  {% set expiryDate = doc.formattedExpiryDate if doc.formattedExpiryDate else i18n.notProvided %}
+  {% set countryOfIssue = doc.countryOfIssue if doc.countryOfIssue else i18n.notProvided %}
   {{ govukSummaryList({
     classes: 'govuk-!-margin-bottom-0',
     rows: [
@@ -167,7 +170,7 @@
         text: i18n.number | replace("{DOCNAME}", i18n[doc.docName])
       },
       value: {
-        text: doc.documentNumber
+        text: docNumber
       }
     },
     {
@@ -175,7 +178,7 @@
         text: i18n[doc.docName] + " " + i18n.ExpiryDate
       },
       value: {
-        text: doc.formattedExpiryDate
+        text: expiryDate
       }
     },
     {
@@ -183,7 +186,7 @@
         text: i18n[doc.docName] + " " + i18n.chooseCountryText
       },
       value: {
-        text: doc.countryOfIssue
+        text: countryOfIssue
       }
     }
     ]

--- a/test/src/services/idDocumentDetailsService.test.ts
+++ b/test/src/services/idDocumentDetailsService.test.ts
@@ -1,10 +1,8 @@
 import { MockRequest, createRequest } from "node-mocks-http";
 import { IdDocumentDetailsService } from "../../../src/services/idDocumentDetailsService";
-import { ClientData } from "../../../src/model/ClientData";
 import { getSessionRequestWithPermission } from "../../mocks/session.mock";
 import { USER_DATA } from "../../../src/utils/constants";
 import { Request } from "express";
-import { Session } from "@companieshouse/node-session-handler";
 jest.mock("../../../src/services/identityVerificationService.ts");
 
 describe("IdDocumentDetailsService tests", () => {
@@ -26,7 +24,7 @@ describe("IdDocumentDetailsService tests", () => {
         req.body.countryInput_1 = "India";
         const formattedDocs = ["UK biometric residence permit (BRP)"];
 
-        service.saveIdDocumentDetails(req, {}, formattedDocs, {});
+        service.saveIdDocumentDetails(req, {}, formattedDocs);
         const date = new Date(2025, 1, 28);
         expect(session.getExtraData(USER_DATA)).toEqual({
             idDocumentDetails: [{
@@ -39,7 +37,7 @@ describe("IdDocumentDetailsService tests", () => {
         });
     });
 
-    it("should set formattedExpiryDate to 'Not provided' when expiry date is not given for optional expiry date ID doc", () => {
+    it("should set formattedExpiryDate to an empty string when expiry date is not given for optional expiry date ID doc", () => {
         // Arrange
         req = createRequest({});
         const session = getSessionRequestWithPermission();
@@ -51,9 +49,8 @@ describe("IdDocumentDetailsService tests", () => {
         req.body.countryInput_1 = "England";
 
         const formattedDocs = ["UK HM Armed Forces Veteran Card"];
-        const i18n = { dateNotProvided: "Not provided" };
 
-        service.saveIdDocumentDetails(req, {}, formattedDocs, i18n);
+        service.saveIdDocumentDetails(req, {}, formattedDocs);
 
         expect(session.getExtraData(USER_DATA)).toEqual({
             idDocumentDetails: [{
@@ -61,12 +58,12 @@ describe("IdDocumentDetailsService tests", () => {
                 documentNumber: "123456789",
                 expiryDate: undefined,
                 countryOfIssue: "England",
-                formattedExpiryDate: "Not provided"
+                formattedExpiryDate: ""
             }]
         });
     });
 
-    it("should set documentNumber to 'Not provided' when document number is not given for optional document number doc", () => {
+    it("should set documentNumber to an empty string when document number is not given for optional document number doc", () => {
         // Arrange
         req = createRequest({});
         const session = getSessionRequestWithPermission();
@@ -78,22 +75,21 @@ describe("IdDocumentDetailsService tests", () => {
         req.body.countryInput_1 = "England";
 
         const formattedDocs = ["Photographic ID listed on PRADO"];
-        const i18n = { dateNotProvided: "Not provided" };
 
-        service.saveIdDocumentDetails(req, {}, formattedDocs, i18n);
+        service.saveIdDocumentDetails(req, {}, formattedDocs);
 
         expect(session.getExtraData(USER_DATA)).toEqual({
             idDocumentDetails: [{
                 docName: "Photographic ID listed on PRADO",
-                documentNumber: "Not provided",
+                documentNumber: "",
                 expiryDate: undefined,
                 countryOfIssue: "England",
-                formattedExpiryDate: "Not provided"
+                formattedExpiryDate: ""
             }]
         });
     });
 
-    it("should set country to 'Not provided' when country is not given for optional country doc", () => {
+    it("should set country to an empty string when country is not given for optional country doc", () => {
         // Arrange
         req = createRequest({});
         const session = getSessionRequestWithPermission();
@@ -105,17 +101,16 @@ describe("IdDocumentDetailsService tests", () => {
         req.body.countryInput_1 = undefined;
 
         const formattedDocs = ["Photographic ID listed on PRADO"];
-        const i18n = { dateNotProvided: "Not provided" };
 
-        service.saveIdDocumentDetails(req, {}, formattedDocs, i18n);
+        service.saveIdDocumentDetails(req, {}, formattedDocs);
 
         expect(session.getExtraData(USER_DATA)).toEqual({
             idDocumentDetails: [{
                 docName: "Photographic ID listed on PRADO",
                 documentNumber: "123456789",
                 expiryDate: undefined,
-                countryOfIssue: "Not provided",
-                formattedExpiryDate: "Not provided"
+                countryOfIssue: "",
+                formattedExpiryDate: ""
             }]
         });
     });


### PR DESCRIPTION
Bug fix for ticket:
[IDVA5-1944](https://companieshouse.atlassian.net/browse/IDVA5-1944?atlOrigin=eyJpIjoiNjcxM2VkYWVlOWE1NDg1ZGFmYjI3ZWE4NzMwODg4YzMiLCJwIjoiaiJ9)

- 'Not provided' text (or the relevant Welsh translation if user was navigating the service in Welsh) was previously being stored in the clientData session object after proceeding from ID Documents Details screen when no data was input under the optional fields for certain ID documents.
- This was causing a translation issue when on the Check your answers screen, as the value was being pulled directly from the session object, regardless of language selection.
- This fix removes storing the text 'Not provided' or relevant Welsh translation within the session object and instead replaces with an empty string for optional fields.
- Check your answers njk view then loops through the ID Document fields and if the docNumber/expiryDate/countryOfIssue are empty, it will replace this with the relevant English/Welsh translation for 'Not provided' 
- Updated confirmation page to reflect change
- Updated tests to reflect change

[IDVA5-1944]: https://companieshouse.atlassian.net/browse/IDVA5-1944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ