### PR TITLE
Error Message amend email address confirmation message

### DIFF
--- a/locales/cy/what-is-persons-email-address.json
+++ b/locales/cy/what-is-persons-email-address.json
@@ -8,7 +8,7 @@
     "continue": "Pharhau",
 
     "error-noEmailAddress" : "Cofnodwch ei gyfeiriad e-bost",
-    "error-noConfirmAddress" : "Cofnodwch ei gyfeiriad e-bost",
+    "error-noConfirmAddress" : "Cadarnhau cyfeiriad e-bost",
     "error-invalidEmail" : "Cofnodwch gyfeiriad e-bost yn y fformat cywir, fel enw@enghraifft.com",
     "error-emailAddressDontMatch": "Rhaid i'r cyfeiriadau e-bost gyfateb"
 }

--- a/locales/en/what-is-persons-email-address.json
+++ b/locales/en/what-is-persons-email-address.json
@@ -8,7 +8,7 @@
     "continue": "Continue",
 
     "error-noEmailAddress" : "Enter their email address",
-    "error-noConfirmAddress" : "Enter their email address",
+    "error-noConfirmAddress" : "Confirm their email address",
     "error-invalidEmail" : "Enter an email address in the correct format, like name@example.com",
     "error-emailAddressDontMatch": "Email addresses must match"
 }

--- a/test/src/controllers/personsEmailController.test.ts
+++ b/test/src/controllers/personsEmailController.test.ts
@@ -63,7 +63,7 @@ describe("POST" + EMAIL_ADDRESS, () => {
         };
         const res = await router.post(BASE_URL + EMAIL_ADDRESS).send(sendData);
         expect(res.status).toBe(400);
-        expect(res.text).toContain("Enter their email address");
+        expect(res.text).toContain("Confirm their email address");
     });
 
     it("should return status 400 after incorrect data entered", async () => {


### PR DESCRIPTION
When entering the verified person's email address, if an empty form is submitted, without providing an email address or confirmation of that email address, then the error summary contains two links with identical 'Enter their email address' text. This affects screen reader users, as the links are indistinguishable from one another, and are not sufficiently descriptive of which fields require correction.

Change text in second error message to say “Confirm their email address”

Welsh: Cadarnhau cyfeiriad e-bost