### PR TITLE
Updating accessibility statement controller to display cookie banner

### DIFF
--- a/src/controllers/accessibilityStatementController.ts
+++ b/src/controllers/accessibilityStatementController.ts
@@ -1,6 +1,13 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
+import { ACCESSIBILITY_STATEMENT, BASE_URL } from "../types/pageURL";
+import { getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
-    res.render(config.ACCESSIBILITY_STATEMENT);
+    const lang = selectLang(req.query.lang);
+    const locales = getLocalesService();
+    res.render(config.ACCESSIBILITY_STATEMENT, {
+        ...getLocaleInfo(locales, lang),
+        currentUrl: BASE_URL + ACCESSIBILITY_STATEMENT
+    });
 };

--- a/src/views/accessibility-statement/accessibility-statement.njk
+++ b/src/views/accessibility-statement/accessibility-statement.njk
@@ -2,6 +2,9 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it with nothing #}
 {% endblock %}
+{% block localesBanner %}
+  {# Remove language banner on this page by replacing it with nothing #}
+{% endblock %}
 {% set title = "Accessibility statement for the Companies House service" %}
 {% block main_content %}
   <div id="search-container">

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -19,7 +19,9 @@
     {% include "partials/__header.njk" %}
     <div class="govuk-width-container">
       {% include "partials/nav/top.njk" %}
-      {% include "locales-banner.njk" %}
+      {% block localesBanner %}
+        {% include "locales-banner.njk" %}
+      {% endblock %}
       {% block backLink %}
         <a href="{{ previousPage }}" class="govuk-back-link">{{i18n.Back}}</a>
       {% endblock %}


### PR DESCRIPTION
Changes made for ticket: 
[IDVA5-1965](https://companieshouse.atlassian.net/browse/IDVA5-1965?atlOrigin=eyJpIjoiZGNhYTM4OTI4MWYzNDI1NGI3MjllZjcxMjRiYzA3YTkiLCJwIjoiaiJ9)

- Adding locales for the accessibility statement controller, as the Cookie Banner text was not displaying on page
- Removing the language toggle from the accessibility statement page as we do not want this to appear on this page
- Adding block for localesBanner in default.njk layout so this can be blocked from pages when not required

[IDVA5-1965]: https://companieshouse.atlassian.net/browse/IDVA5-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ