### PR TITLE
Map biometric_passport to passport when sending to Verification API

### DIFF
--- a/src/services/identityVerificationService.ts
+++ b/src/services/identityVerificationService.ts
@@ -94,7 +94,9 @@ export class IdentityVerificationService {
 
         const documentsChecked = clientData.documentsChecked!;
         const verificationEvidence = documentsChecked.map((document) => {
-            return { type: document as unknown as VerificationType };
+            // Map biometric_passport to passport to be accepted by Verification Api
+            const documentType = document === "biometric_passport" ? "passport" : document;
+            return { type: documentType as unknown as VerificationType };
         });
 
         return {

--- a/src/services/identityVerificationService.ts
+++ b/src/services/identityVerificationService.ts
@@ -6,6 +6,7 @@ import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/res
 import { createPrivateApiKeyClient } from "./apiService";
 import { ClientData } from "model/ClientData";
 import { getLoggedInAcspNumber, getLoggedInUserId } from "../utils/session";
+import { BIOMETRIC_PASSPORT, PASSPORT } from "../utils/constants";
 
 export const findIdentityByEmail = async (email: string): Promise<Identity | undefined> => {
     const apiClient = createPrivateApiKeyClient();
@@ -95,7 +96,7 @@ export class IdentityVerificationService {
         const documentsChecked = clientData.documentsChecked!;
         const verificationEvidence = documentsChecked.map((document) => {
             // Map biometric_passport to passport to be accepted by Verification Api
-            const documentType = document === "biometric_passport" ? "passport" : document;
+            const documentType = document === BIOMETRIC_PASSPORT ? PASSPORT : document;
             return { type: documentType as unknown as VerificationType };
         });
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,6 +4,8 @@ export const PREVIOUS_PAGE_URL: string = "previouspageurl";
 export const REFERENCE = "reference";
 export const CHECK_YOUR_ANSWERS_FLAG = "checkYourAnswersFlag";
 export const ACSP_DETAILS = "acspDetails";
+export const BIOMETRIC_PASSPORT = "biometric_passport";
+export const PASSPORT = "passport";
 
 // Matomo
 export const MATOMO_LINK_CLICK = "Click link";

--- a/test/mocks/identity.mock.ts
+++ b/test/mocks/identity.mock.ts
@@ -90,3 +90,24 @@ export const clientDetails = {
     howIdentityDocsChecked: "",
     whenIdentityChecksCompleted: new Date()
 };
+
+export const clientDetailsBiometricPassport = {
+    firstName: "John",
+    middleName: "A",
+    lastName: "Doe",
+    dateOfBirth: new Date(),
+    address: {
+        line1: "123 Main St",
+        line2: "Apt 4",
+        county: "County",
+        town: "Town",
+        country: "Country",
+        postcode: "12345",
+        propertyDetails: "Property Details"
+    },
+    documentsChecked: ["biometric_passport"],
+    emailAddress: "john.doe@example.com",
+    confirmEmailAddress: "john.doe@example.com",
+    howIdentityDocsChecked: "",
+    whenIdentityChecksCompleted: new Date()
+};

--- a/test/src/services/identityVerificationService.test.ts
+++ b/test/src/services/identityVerificationService.test.ts
@@ -2,10 +2,11 @@ import { Request } from "express";
 import { Resource } from "@companieshouse/api-sdk-node";
 import { Session } from "@companieshouse/node-session-handler";
 import { createPrivateApiClient } from "private-api-sdk-node";
-import { Identity } from "private-api-sdk-node/dist/services/identity-verification/types";
+import { Identity, VerifiedClientData } from "private-api-sdk-node/dist/services/identity-verification/types";
 import { IdentityVerificationService, findIdentityByEmail, sendVerifiedClientDetails } from "../../../src/services/identityVerificationService";
 import { dummyIdentity, verifiedClientDetails, clientDetails } from "../../mocks/identity.mock";
 import { createRequest, MockRequest } from "node-mocks-http";
+import { ClientData } from "../../../src/model/ClientData";
 
 jest.mock("private-api-sdk-node");
 
@@ -150,6 +151,37 @@ describe("verification api service tests", () => {
             expect(actualVerifiedClientData.currentAddress.postalCode).toEqual(verifiedClientDetails.currentAddress.postalCode);
             expect(actualVerifiedClientData.currentAddress.premises).toEqual(verifiedClientDetails.currentAddress.premises);
             expect(actualVerifiedClientData.currentAddress.region).toEqual(verifiedClientDetails.currentAddress.region);
+        });
+
+        it("should map biometric_passport to passport in verificationEvidence", () => {
+            const clientData: ClientData = {
+                firstName: "John",
+                middleName: "A.",
+                lastName: "Doe",
+                preferredFirstName: "Johnny",
+                preferredMiddleName: "A.",
+                preferredLastName: "Doe",
+                emailAddress: "john.doe@example.com",
+                whenIdentityChecksCompleted: new Date().toISOString(),
+                howIdentityDocsChecked: "manual",
+                dateOfBirth: new Date("1990-01-01").toISOString(),
+                address: {
+                    line1: "123 Main St",
+                    line2: "Apt 4",
+                    county: "County",
+                    town: "Town",
+                    country: "Country",
+                    postcode: "12345",
+                    propertyDetails: "Property Details"
+                },
+                documentsChecked: ["biometric_passport"]
+            };
+            const identityVerificationService = new IdentityVerificationService();
+            const result = identityVerificationService.prepareVerifiedClientData(clientData, req);
+
+            expect(result.verificationEvidence).toEqual([
+                { type: "passport" }
+            ]);
         });
     });
 });

--- a/test/src/services/identityVerificationService.test.ts
+++ b/test/src/services/identityVerificationService.test.ts
@@ -4,9 +4,8 @@ import { Session } from "@companieshouse/node-session-handler";
 import { createPrivateApiClient } from "private-api-sdk-node";
 import { Identity } from "private-api-sdk-node/dist/services/identity-verification/types";
 import { IdentityVerificationService, findIdentityByEmail, sendVerifiedClientDetails } from "../../../src/services/identityVerificationService";
-import { dummyIdentity, verifiedClientDetails, clientDetails } from "../../mocks/identity.mock";
+import { dummyIdentity, verifiedClientDetails, clientDetails, clientDetailsBiometricPassport } from "../../mocks/identity.mock";
 import { createRequest, MockRequest } from "node-mocks-http";
-import { ClientData } from "../../../src/model/ClientData";
 
 jest.mock("private-api-sdk-node");
 
@@ -154,30 +153,8 @@ describe("verification api service tests", () => {
         });
 
         it("should map biometric_passport to passport in verificationEvidence", () => {
-            const clientData: ClientData = {
-                firstName: "John",
-                middleName: "A.",
-                lastName: "Doe",
-                preferredFirstName: "Johnny",
-                preferredMiddleName: "A.",
-                preferredLastName: "Doe",
-                emailAddress: "john.doe@example.com",
-                whenIdentityChecksCompleted: new Date().toISOString(),
-                howIdentityDocsChecked: "manual",
-                dateOfBirth: new Date("1990-01-01").toISOString(),
-                address: {
-                    line1: "123 Main St",
-                    line2: "Apt 4",
-                    county: "County",
-                    town: "Town",
-                    country: "Country",
-                    postcode: "12345",
-                    propertyDetails: "Property Details"
-                },
-                documentsChecked: ["biometric_passport"]
-            };
             const identityVerificationService = new IdentityVerificationService();
-            const result = identityVerificationService.prepareVerifiedClientData(clientData, req);
+            const result = identityVerificationService.prepareVerifiedClientData(clientDetailsBiometricPassport, req);
 
             expect(result.verificationEvidence).toEqual([
                 { type: "passport" }

--- a/test/src/services/identityVerificationService.test.ts
+++ b/test/src/services/identityVerificationService.test.ts
@@ -2,7 +2,7 @@ import { Request } from "express";
 import { Resource } from "@companieshouse/api-sdk-node";
 import { Session } from "@companieshouse/node-session-handler";
 import { createPrivateApiClient } from "private-api-sdk-node";
-import { Identity, VerifiedClientData } from "private-api-sdk-node/dist/services/identity-verification/types";
+import { Identity } from "private-api-sdk-node/dist/services/identity-verification/types";
 import { IdentityVerificationService, findIdentityByEmail, sendVerifiedClientDetails } from "../../../src/services/identityVerificationService";
 import { dummyIdentity, verifiedClientDetails, clientDetails } from "../../mocks/identity.mock";
 import { createRequest, MockRequest } from "node-mocks-http";


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1938

After Check Your Answers, if user had selected "biometric_passport" as a document this was throwing an error in Verification Api as only "passport" is an accepted value.

So before sending the data, if user has selected "biometric_passport", it is now mapped to "passport" in the identityVerificationService.