### PR TITLE
Removing users email address from analytics when they click the show …

### DIFF
--- a/src/views/partials/piwik.njk
+++ b/src/views/partials/piwik.njk
@@ -69,6 +69,8 @@
         // Provide different email stop screen - removes user name from link analytics
         if ($(this).attr('id') && $(this).attr('id') === "provide-different-email-link-id") {
           textOnHrefClick = $(this).text().split('for')[0];
+        } else if ($(this).attr('href') && $(this).attr('href') === "#navigation") {
+          textOnHrefClick = $(this).children().text()
         } else {
           textOnHrefClick = $(this).text();
         }  


### PR DESCRIPTION
Ticket: [IDVA5-2020](https://companieshouse.atlassian.net/browse/IDVA5-2020)

Removing users email address from analytics when they click the show hide link on mobile view
This is done by getting the link with the href navigation and then setting the matomo text to just the text inside the span
