### PR TITLE
Adding current url into form action attribute for all njk files

### DIFF
--- a/src/views/check-your-answers/check-your-answers.njk
+++ b/src/views/check-your-answers/check-your-answers.njk
@@ -49,7 +49,7 @@
 
   {% set groupBDocs = [i18n.birth_certificate, i18n.marriage_certificate, i18n.immigration_document_non_photo_id, i18n.visa_non_photo_id, i18n.work_permit_non_photo_id, i18n.bank_statement, i18n.rental_agreement, i18n.mortgage_statement, i18n.UK_council_tax_statement, i18n.utility_bill] %}
 
-  <form action="" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     <h1 class="govuk-heading-xl">{{ i18n.checkYourAnswersHeading }}</h1>
     <h2 class="govuk-heading-m">{{ i18n.checkYourAnswersDetailsTableHeading | replace("{NAME}", fullName) }}</h2>

--- a/src/views/confirm-home-address/confirm-home-address.njk
+++ b/src/views/confirm-home-address/confirm-home-address.njk
@@ -3,7 +3,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.addressConfirmTitle %}
 {% block main_content %}
-  <form class="form" action="" method="post">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="post" class="form">
     {% include "partials/csrf_token.njk" %}
     {% include "partials/user_name.njk" %}
     {% set addressField = address.propertyDetails + " " + address.line1 + ", " %}

--- a/src/views/confirm-identity-verification/confirm-identity-verification.njk
+++ b/src/views/confirm-identity-verification/confirm-identity-verification.njk
@@ -35,7 +35,7 @@
     </strong>
 </div>
 
-<form action="" method="POST">
+<form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {{ govukCheckboxes({
         name: "declaration",

--- a/src/views/home-address-list/home-address-list.njk
+++ b/src/views/home-address-list/home-address-list.njk
@@ -18,7 +18,7 @@
     {% endfor %}
     
     {# Form section #}
-    <form action="" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         {% if firstName %}
             {% include "partials/user_name.njk" %}

--- a/src/views/home-address-manual/home-address-manual.njk
+++ b/src/views/home-address-manual/home-address-manual.njk
@@ -6,7 +6,7 @@
 {% set title = i18n.homeAddressManualTitle %}
 
 {% block main_content %}
-  <form action="" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {% include "partials/user_name.njk" %} 
     {{ govukFieldset({

--- a/src/views/home-address/home-address.njk
+++ b/src/views/home-address/home-address.njk
@@ -4,7 +4,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.homeAddressTitle %}
 {% block main_content %}
-  <form action="" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {% include "partials/user_name.njk" %}
     <h1 class="govuk-heading-l">

--- a/src/views/how-identity-documents-checked/how-identity-documents-checked.njk
+++ b/src/views/how-identity-documents-checked/how-identity-documents-checked.njk
@@ -6,7 +6,7 @@
 {% set title = i18n.howIdentityDocsCheckedTabTitle %}
 
 {% block main_content %}
-  <form action="" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {% include "partials/user_name.njk" %}
     <div class="govuk-form-group">

--- a/src/views/id-document-details/id-document-details.njk
+++ b/src/views/id-document-details/id-document-details.njk
@@ -9,7 +9,7 @@
 {% set otherOptionalDocs = [i18n.PRADO_supported_photo_id, i18n.work_permit_photo_id] %}
 
 {% block main_content %}
-  <form action="" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     <h1 class="govuk-heading-l"> {{ i18n.idDocumentDetailstitle }} </h1>
     {% for body in documentsChecked %}

--- a/src/views/identity-checks-completed/identity-checks-completed.njk
+++ b/src/views/identity-checks-completed/identity-checks-completed.njk
@@ -19,7 +19,7 @@
   {% endif %}
 
    <div>
-     <form action="" method="POST">
+     <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
        {% include "partials/csrf_token.njk" %}
        {% include "partials/user_name.njk" %}
 

--- a/src/views/identity-documents-group-1/identity-documents-group-1.njk
+++ b/src/views/identity-documents-group-1/identity-documents-group-1.njk
@@ -4,7 +4,7 @@
 {% set title = i18n.identityDocumentsIDVTitle %}
 
 {% block main_content %}
-    <form action="" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         {% include "partials/user_name.njk" %} 
         {{ govukCheckboxes({

--- a/src/views/identity-documents-group-2/identity-documents-group-2.njk
+++ b/src/views/identity-documents-group-2/identity-documents-group-2.njk
@@ -3,7 +3,7 @@
 i18n.identityDocumentsIDVTitle %}
 
 {% block main_content %}
-    <form action="" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         {% include "partials/user_name.njk" %}
         <h1 class="govuk-heading-l">{{i18n.identityDocumentsIDVTitle}}</h1>

--- a/src/views/index/home.njk
+++ b/src/views/index/home.njk
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block main_content %}
-    <form action="" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         <h1 class="govuk-heading-l">{{ i18n.startPageTitle }}</h1>
 

--- a/src/views/name-public-register/name-public-register.njk
+++ b/src/views/name-public-register/name-public-register.njk
@@ -4,7 +4,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.namePublicRegisterTitle %}
 {% block main_content %}
-    <form action="" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         <div class="govuk-form-group">
             <h1 class="govuk-heading-l">{{ i18n.namePublicRegisterTitle }}</h1>

--- a/src/views/personal-code/personal-code.njk
+++ b/src/views/personal-code/personal-code.njk
@@ -4,7 +4,7 @@
 {% set title =  i18n.codePageHeading | replace('{NAME}', firstName + ' ' + lastName) %}
 
 {% block main_content %}
-    <form action="" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         <h1 class="govuk-heading-l">
        {{ i18n.codePageHeading | replace("{NAME}", firstName + " " + lastName)}}

--- a/src/views/persons-email/persons-email.njk
+++ b/src/views/persons-email/persons-email.njk
@@ -6,7 +6,7 @@
 {% set title = i18n.whatIs + i18n.emailAddress | replace('{NAME}', firstName + ' ' + lastName) %}
 
 {% block main_content %}
-    <form action="" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         <div class="govuk-form-group">
            

--- a/src/views/persons-name/persons-name.njk
+++ b/src/views/persons-name/persons-name.njk
@@ -4,7 +4,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.whatIsYourNameTitle %}
 {% block main_content %}
-    <form action="" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         <div class="govuk-form-group">
             <h1 class="govuk-heading-l">{{ i18n.whatIsYourNameTitle }}</h1>

--- a/src/views/sign-out-page/sign-out.njk
+++ b/src/views/sign-out-page/sign-out.njk
@@ -10,7 +10,7 @@
 
 {% set title = i18n.signoutTitle %}
 {% block main_content %}
-	<form action="" method="POST">
+	<form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
 	    {% include "partials/csrf_token.njk" %}
 		{{ govukRadios({
 			errorMessage: errors.signout if errors,

--- a/src/views/use-name-on-public-register/use-name-on-public-register.njk
+++ b/src/views/use-name-on-public-register/use-name-on-public-register.njk
@@ -9,7 +9,7 @@
 {% set matomoTitle = i18n.useNameOnPublicRegisterTitle  %}
 
 {% block main_content %}
-  <form action="" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {% include "partials/user_name.njk" %}
     <div class="govuk-form-group">

--- a/src/views/what-is-their-date-of-birth/what-is-their-date-of-birth.njk
+++ b/src/views/what-is-their-date-of-birth/what-is-their-date-of-birth.njk
@@ -18,7 +18,7 @@
   {% endif %}
 
   <div>
-    <form action="" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
       {% include "partials/csrf_token.njk" %}
       {% include "partials/user_name.njk" %}
       
@@ -95,8 +95,5 @@
       }) }}
     </form>
   </div>
-
-<!-- Calling Matomo event script to capture event actions based on page title -->
-
-
+  
 {% endblock main_content %}


### PR DESCRIPTION
Changes made for ticket:
[IDVA5-2013](https://companieshouse.atlassian.net/browse/IDVA5-2013?atlOrigin=eyJpIjoiNTA4OWJiZmYyODQ4NGNhNzhiMWFlNDcyYmIwOWU3NjYiLCJwIjoiaiJ9)

Adding current url into form action attribute for all njk files this removed the #main-page-content from the url when navigating to the next page
Including lang query param in current url to retain language selection when navigating between pages (lang is pulled from common_variables_middleware)

[IDVA5-2013]: https://companieshouse.atlassian.net/browse/IDVA5-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ