### PR TITLE
Updating id docs fieldsets to remove h1 headings

### DIFF
--- a/src/views/identity-documents-group-1/identity-documents-group-1.njk
+++ b/src/views/identity-documents-group-1/identity-documents-group-1.njk
@@ -12,7 +12,8 @@
             fieldset: {
                 legend: {
                     text: i18n.identityDocumentsIDVTitle,
-                    classes: "govuk-fieldset__legend--m"
+                    isPageHeading: true,
+                    classes: "govuk-fieldset__legend--l"
                 }
             },
             hint: {

--- a/src/views/identity-documents-group-1/identity-documents-group-1.njk
+++ b/src/views/identity-documents-group-1/identity-documents-group-1.njk
@@ -12,8 +12,7 @@
             fieldset: {
                 legend: {
                     text: i18n.identityDocumentsIDVTitle,
-                    isPageHeading: true,
-                    classes: "govuk-fieldset__legend--l"
+                    classes: "govuk-fieldset__legend--m"
                 }
             },
             hint: {

--- a/src/views/identity-documents-group-2/identity-documents-group-2.njk
+++ b/src/views/identity-documents-group-2/identity-documents-group-2.njk
@@ -13,7 +13,6 @@ i18n.identityDocumentsIDVTitle %}
             fieldset: {
                 legend: {
                     text: i18n.textGroupA,
-                    isPageHeading: true,
                     classes: "govuk-fieldset__legend--m"
                 }
             },
@@ -111,7 +110,6 @@ i18n.identityDocumentsIDVTitle %}
             fieldset: {
                 legend: {
                     text: i18n.textGroupB,
-                    isPageHeading: true,
                     classes: "govuk-fieldset__legend--m"
                 }
             },


### PR DESCRIPTION
Changes made for ticket:
[IDVA5-2011](https://companieshouse.atlassian.net/browse/IDVA5-2011?atlOrigin=eyJpIjoiZjRmMDVmZmM1ZjZkNDg5ZWE0OTVlYjY3ZjMxOGMzMzciLCJwIjoiaiJ9)

- Updating fieldset subheadings on ID documents page to not use H1 headings for "Group A" and "Group B" text

[IDVA5-2011]: https://companieshouse.atlassian.net/browse/IDVA5-2011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ