### PR TITLE
Mobile navbar stylings to toggle show/hide

### DIFF
--- a/assets/src/scss/__global.scss
+++ b/assets/src/scss/__global.scss
@@ -134,6 +134,20 @@ ul#navigation li a {
   margin-left: 0.9em;
 }
 
+@media (max-width: 640px) {
+  ul#navigation {
+    font-size: 0.9em;
+    margin-top: 15px;
+    margin-bottom: 15px;
+    text-align: left;
+    float: left;
+    display: contents;
+  }
+  .mobile-hidden {
+    display: none !important;
+  }
+}
+
 .js-signout {
   text-align: right;
   font-size: 16px;


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2014

Stylings added to move the navbar links above the language toggle and align left. Override .mobile-hidden with !important to allow the toggle to show and hide correctly when the class is added by js script. All apply only in mobile view.

![image](https://github.com/user-attachments/assets/50d4b434-e043-4254-b15f-a343bd8ca38b)
![image](https://github.com/user-attachments/assets/5396050e-851f-446b-981f-49aa155c0d74)
