### PR TITLE
Updating accessibility page content

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -8,5 +8,5 @@
     "AcceptAndContinue": "Accept and Continue",
     "warning": "Warning",
     "companiesHouseDoesNotVerify": "Companies House does not verify the accuracy of the information filed",
-   "matomoPageTitle": " Tell Companies House you have verified someone’s identity - GOV.UK" 
+    "matomoPageTitle": " Tell Companies House you have verified someone’s identity - GOV.UK" 
 }

--- a/src/views/accessibility-statement/accessibility-statement.njk
+++ b/src/views/accessibility-statement/accessibility-statement.njk
@@ -1,3 +1,4 @@
+{% set hideCompaniesHouseDoesNotVerifyText = true %} {# by setting this to true, we are hiding the 'Companies House does not verify the accuracy of the information filed' text from this page only #}
 {% extends "layouts/default.njk" %}
 {% block backLink %}
   {# Remove back button on this page by replacing it with nothing #}
@@ -5,143 +6,120 @@
 {% block localesBanner %}
   {# Remove language banner on this page by replacing it with nothing #}
 {% endblock %}
-{% set title = "Accessibility statement for the Companies House service" %}
+{% block navBar %}
+  {# Remove nav bar on this page by replacing it with nothing #}
+{% endblock %}
+{% set title = "Accessibility statement for the Tell Companies House you have verified someone's identity service" %}
 {% block main_content %}
   <div id="search-container">
     <article class="text" id="page-content">
-      <h1 class="govuk-heading-xl">
-        Accessibility statement for the Companies House service
+      <h1 class="govuk-heading-l">
+        Accessibility statement for the Tell Companies House you have verified someone's identity service
       </h1>
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a href="#about-service">About this service</a>
+          <a class="govuk-link" href="#about-service">About this service</a>
         </li>
         <li>
-          <a href="#how-accessible">How accessible this service is</a>
+          <a class="govuk-link" href="#how-accessible">How accessible this service is</a>
         </li>
         <li>
-          <a href="#reporting-accessibility">Reporting accessibility problems with this service</a>
+          <a class="govuk-link" href="#feedback-and-contact-information">Feedback and contact information</a>
         </li>
         <li>
-          <a href="#enforcement">Enforcement procedure</a>
+          <a class="govuk-link" href="#enforcement">Enforcement procedure</a>
         </li>
         <li>
-          <a href="#technical-information">Technical information about this service’s accessibility</a>
+          <a class="govuk-link" href="#technical-information">Technical information about this service's accessibility</a>
         </li>
         <li>
-          <a href="#tested">How we tested this service</a>
+          <a class="govuk-link" href="#were-doing">What we’re doing to improve accessibility</a>
         </li>
         <li>
-          <a href="#were-doing">What we’re doing to improve accessibility</a>
+          <a class="govuk-link" href="#preparation-of-statement">Preparation of this accessibility statement</a>
         </li>
       </ul>
       <h2 class="govuk-heading-m" id="about-service">
         About this service
       </h2>
-      <p class="govuk-body">This accessibility statement applies to the ‘Find and update company information' service.</p>
+      <p class="govuk-body">This accessibility statement applies to Tell Companies House you have verified someone's identity service.</p>
       <p class="govuk-body">This service is run by
         <a class="govuk-link" href="https://www.gov.uk/government/organisations/companies-house">Companies House</a>. We want as many people as possible to be able to use this service. For example, that means you should be able to:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>change colours, contrast levels, and fonts</li>
-        <li>zoom in up to 300% without the text disappearing off the screen</li>
-        <li>navigate most of the service using just a keyboard</li>
-        <li>navigate most of the service using speech recognition software</li>
-        <li>listen to most of the service using a screen reader (including the most recent versions of JAWS, NVDA, and VoiceOver)</li>
+        <li>change colours, contrast levels and fonts using browser or device settings</li>
+        <li>zoom in up to 400% without the text spilling off the screen</li>
+        <li>navigate most of the website using a keyboard or speech recognition software</li>
+        <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
       </ul>
-      <p class="govuk-body">We’ve also made the website text simple to understand.</p>
+      <p class="govuk-body">We've also made the service text as simple as possible to understand.</p>
       <p class="govuk-body">
-        <a class="govuk-link" href="https://mcmw.abilitynet.org.uk/">AbilityNet has advice on making your device easier to use
-          if you have a disability.</a>
+        <a class="govuk-link" href="https://www.gov.uk/guidance/accessibility-support-for-companies-house-users">Find out more about accessibility support for Companies House users</a>.
       </p>
+      <div class="govuk-inset-text">
+        <a class="govuk-link" href="https://mcmw.abilitynet.org.uk/">
+          AbilityNet has advice on making your device easier to use if you have a disability</a>.
+      </div>
       <h2 class="govuk-heading-m" id="how-accessible">
         How accessible this service is
       </h2>
-      <p class="govuk-body">We know some parts of this service aren’t fully accessible:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>some PDF documents are not accessible in a few ways, including missing text alternatives and missing document structure</li>
-      </ul>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>due to a known bug in the Chrome web browser, in some circumstances users of assistive technology such as screen
-          readers may get presented with incorrect information when using our accounts filing service</li>
-      </ul>
-      <h2 class="govuk-heading-m" id="reporting-accessibility">
-        Reporting accessibility problems with this service
+      <p class="govuk-body">This service is fully accessible.</p>
+      <h2 class="govuk-heading-m" id="feedback-and-contact-information">
+        Feedback and contact information
       </h2>
-      <p class="govuk-body">We’re always looking to improve the accessibility of this service. If you find any problems not
-        listed on this page or think we’re not meeting accessibility requirements, you can find contact details on our
+      <p class="govuk-body">We're always looking to improve the accessibility of this service.</p>
+      <p class="govuk-body">If you find any problems that are not listed on this page, contact us using the details on our
         <a class="govuk-link" href="https://www.gov.uk/guidance/accessibility-support-for-companies-house-users">
-          accessibility support for Companies House users</a>
-        page.
+          accessibility support guidance</a>.
       </p>
       <h2 class="govuk-heading-m" id="enforcement">
         Enforcement procedure
       </h2>
-      <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector
-        Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If
-        you’re not happy with how we respond to your complaint,
-        <a class="govuk-link" href="https://www.equalityadvisoryservice.com/">contact the Equality Advisory and Support Service
-          (EASS)</a>.
+      <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for 
+        enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 
+        2) Accessibility Regulations 2018 (the ‘accessibility regulations'). If you're 
+        not happy with how we respond to your complaint,
+        <a class="govuk-link" href="https://www.equalityadvisoryservice.com/">contact the Equality 
+          Advisory and Support Service (EASS)</a>.
       </p>
       <h2 class="govuk-heading-m" id="technical-information">
-        Technical information about this service’s accessibility
+        Technical information about this service's accessibility
       </h2>
-      <p class="govuk-body">Companies House is committed to making its website accessible in accordance with the Public Sector
-        Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
-      <p class="govuk-body">This service is partially compliant with the
-        <a class="govuk-link" href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a>
-        AA standard, due to the non-compliances listed below.
+      <p class="govuk-body">Companies House is committed to making its website accessible in 
+        accordance with the Public Sector Bodies (Websites and Mobile 
+        Applications) (No. 2) Accessibility Regulations 2018.</p>
+      <h2 class="govuk-heading-m">
+        Compliance status
+      </h2>
+      <p class="govuk-body">This website is partially compliant with the <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility 
+        Guidelines version 2.2</a> AA standard, due to the non-compliances listed below.
       </p>
-      <h2 class="govuk-heading-m">
-        Users of screen reading technology
-      </h2>
-      <p class="govuk-body">In some circumstances, users of screen reader technology may get presented with incorrect
-        information when using our accounts filing service. This doesn’t meet WCAG 2.1 Success Criterion 3.3.2 (Labels or
-        Instructions). This is a known bug in the Chrome web browser - these types of bugs are usually fixed by future updates
-        to the browser.</p>
-      <h2 class="govuk-heading-m">
-        PDFs and other documents
-      </h2>
-      <p class="govuk-body">Many of our PDFs don’t meet accessibility standards - for example, they may not be structured so
-        they’re accessible to a screen reader. This doesn’t meet WCAG 2.1 success criterion 4.1.2 (name, role value). We are
-        currently fixing these PDFs.</p>
-      <h2 class="govuk-heading-m" id="tested">
-        How we tested this service
-      </h2>
-      <p class="govuk-body">We regularly carry out internal tests for compliance with the Web Content Accessibility Guidelines
-        V2.1 level A and level AA using a variety of manual and automated testing tools.</p>
-      <p class="govuk-body">This service was last (externally) audited on 19 July 2022. The audit was carried out by the
-        <a href="https://digitalaccessibilitycentre.org/" class="govuk-link">Digital Accessibility Centre</a>.</p>
-      <p class="govuk-body">They tested:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Sign in/Register</li>
-        <li>Search for a company</li>
-        <li>Search for a company officer</li>
-        <li>Your filings</li>
-        <li>The company profile</li>
-      </ul>
       <h2 class="govuk-heading-m" id="were-doing">
         What we’re doing to improve accessibility
       </h2>
       <p class="govuk-body">To improve this service's accessibility, we:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>work with real users who have accessibility issues to make sure that our services meet their needs</li>
-        <li>carry out internal tests for compliance with Web Content Accessibility Guidelines V2.1 level A and level AA</li>
-        <li>work with external agencies in major UK cities to perform usability research with users</li>
-        <li>recruit customers through
+        <li>carry out internal tests for compliance with Web Content Accessibility Guidelines V2.2 level A and level AA</li>
+        <li>recruit users through
           <a class="govuk-link" href="https://www.gov.uk/government/news/help-improve-companies-house">our user panel</a>
-          to take part in sessions at our usability lab in Cardiff</li>
+          and agencies to take part in usability sessions</li>
         <li>build and test our services to meet
-          <a
-            class="govuk-link"
+          <a class="govuk-link"
             href="https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction#meeting-government-accessibility-requirements">
-          government accessibility requirements</a>
+            government accessibility requirements</a>
         </li>
       </ul>
-      <br>
-        <p class="govuk-body">
-          <a class="govuk-link" href="https://companieshouse.blog.gov.uk/category/user-research/">Read our blogs about usability</a>
-          to find out more about our user research work.</p>
-        <p class="govuk-body">This statement was prepared on 7 May 2020. It was last updated on 30 August 2022.</p>
+      <p class="govuk-body">
+        <a class="govuk-link" href="https://companieshouse.blog.gov.uk/category/user-research/">Read our blogs about usability</a>
+        to find out more about our user research work.</p>
+      <h2 class="govuk-heading-m" id="preparation-of-statement">
+        Preparation of this accessibility statement
+      </h2>
+        <p class="govuk-body">This statement was prepared on 8 April 2025. It was last reviewed on 8 April 2025.</p>
+        <p class="govuk-body">This service was last tested on 5 February 2025. The test was carried out by the
+          <a class="govuk-link" href="https://digitalaccessibilitycentre.org/auditandaccreditation.html">Digital Accessibility Centre</a>.
+          They tested the main journey.
+        </p>
       </article>
     </div>
-  {% endblock %}
+{% endblock %}

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -18,7 +18,9 @@
     <a href="#main-page-content" class="govuk-skip-link">Skip to main content</a>
     {% include "partials/__header.njk" %}
     <div class="govuk-width-container">
-      {% include "partials/nav/top.njk" %}
+      {% block navBar %}
+        {% include "partials/nav/top.njk" %}
+      {% endblock %}
       {% block localesBanner %}
         {% include "locales-banner.njk" %}
       {% endblock %}

--- a/src/views/partials/__header.njk
+++ b/src/views/partials/__header.njk
@@ -18,10 +18,12 @@
     </p>
   </div>
 </div>
-
+{% if not hideCompaniesHouseDoesNotVerifyText %}
+{# This will allow us to conditionally set wether this text is hidden on specific pages (this is currenly only applicable to accessibility statement view, as we do not want this text to appear) #}
 <div class="govuk-width-container small-text does-not-verify-link-spacing">
   <a class="govuk-link govuk-link--no-visited-state govuk-!-padding-top-2" href="https://resources.companieshouse.gov.uk/serviceInformation.shtml" target="_blank">
       {{i18n.companiesHouseDoesNotVerify}}
       <span class="govuk-visually-hidden">(link opens a new window)</span>
   </a>
 </div>
+{% endif %}

--- a/test/src/controllers/accessibilityStatementController.test.ts
+++ b/test/src/controllers/accessibilityStatementController.test.ts
@@ -10,6 +10,6 @@ describe("GET" + ACCESSIBILITY_STATEMENT, () => {
         const response = await router.get(BASE_URL + ACCESSIBILITY_STATEMENT);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalledTimes(0);
         expect(response.status).toBe(200);
-        expect(response.text).toContain("Accessibility statement for the Companies House service");
+        expect(response.text).toContain("Accessibility statement for the Tell Companies House you have verified someone's identity service");
     });
 });


### PR DESCRIPTION
Changes made for ticket:
[IDVA5-2002](https://companieshouse.atlassian.net/browse/IDVA5-2002?atlOrigin=eyJpIjoiNGJmOTQzZDI5MGRiNDEwZThkZmNjY2FjNTg3ZTFjYzkiLCJwIjoiaiJ9)

- Updating accessibility page content to match prototype
- Updating content specific to Verify service, as listed on ticket description
- Removing Navbar display from accessibility statement page (to match how we approach this on Registration service)
- Adding logic for "Companies House does not verify the accuracy of the information filed" header text display (this should not be displayed on accessibility page)
- Updating test

[IDVA5-2002]: https://companieshouse.atlassian.net/browse/IDVA5-2002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ