### PR TITLE
Fixing subheading to display Group A text

### DIFF
--- a/src/views/identity-documents-group-2/identity-documents-group-2.njk
+++ b/src/views/identity-documents-group-2/identity-documents-group-2.njk
@@ -13,7 +13,7 @@ i18n.identityDocumentsIDVTitle %}
             fieldset: {
                 legend: {
                     isPageHeading: false,
-                    html: "<h2 class='govuk-heading-m'>"+i18n.textGroupB+"</h2>"
+                    html: "<h2 class='govuk-heading-m'>"+i18n.textGroupA+"</h2>"
                 }
             },
 


### PR DESCRIPTION
- Fixing subheading text to display 'Group A' on ID docs screen