### PR TITLE
New middleware to clear session

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -27,6 +27,7 @@ import nocache from "nocache";
 import { prepareCSPConfig } from "./middleware/content_security_policy_middleware_config";
 import { csrfProtectionMiddleware } from "./middleware/csrf_protection_middleware";
 import errorHandler from "./controllers/csrfErrorController";
+import { clearSessionAfterConfirmation } from "./middleware/clear_session_after_confirmation_middleware";
 const app = express();
 
 const nonce: string = uuidv4();
@@ -72,6 +73,7 @@ app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}|${BASE_URL}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, csrfProtectionMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, authenticationMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, acspAuthMiddleware);
+app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, clearSessionAfterConfirmation);
 app.use(commonTemplateVariablesMiddleware);
 
 app.use((req: Request, res: Response, next: NextFunction) => {

--- a/src/middleware/clear_session_after_confirmation_middleware.ts
+++ b/src/middleware/clear_session_after_confirmation_middleware.ts
@@ -1,0 +1,19 @@
+import { Session } from "@companieshouse/node-session-handler";
+import { CONFIRMATION } from "../types/pageURL";
+
+import { Request, Response, NextFunction } from "express";
+import { CHECK_YOUR_ANSWERS_FLAG, USER_DATA } from "../utils/constants";
+
+export function clearSessionAfterConfirmation (req: Request, res: Response, next: NextFunction) {
+    const session: Session = req.session as any as Session;
+    // Check if the user is navigating away from the confirmation page
+    if (req.headers.referer?.includes(CONFIRMATION)) {
+
+        if (req.query.lang) {
+            return next();
+        }
+        session.deleteExtraData(USER_DATA);
+        session.deleteExtraData(CHECK_YOUR_ANSWERS_FLAG);
+    }
+    next();
+}

--- a/test/src/middleware/clear_session_after_confirmation_middleware.test.ts
+++ b/test/src/middleware/clear_session_after_confirmation_middleware.test.ts
@@ -1,0 +1,56 @@
+import { clearSessionAfterConfirmation } from "../../../src/middleware/clear_session_after_confirmation_middleware";
+import { Request, Response, NextFunction } from "express";
+import { CONFIRMATION, PERSONS_NAME } from "../../../src/types/pageURL";
+import { CHECK_YOUR_ANSWERS_FLAG, USER_DATA } from "../../../src/utils/constants";
+import { Session } from "@companieshouse/node-session-handler";
+
+describe("clearSessionAfterConfirmation Middleware", () => {
+    let req: Partial<Request>;
+    let res: Partial<Response>;
+    let next: NextFunction;
+    let sessionMock: Partial<Session>;
+
+    beforeEach(() => {
+        sessionMock = {
+            deleteExtraData: jest.fn()
+        };
+
+        req = {
+            headers: {},
+            session: sessionMock as Session
+        };
+
+        res = {};
+        next = jest.fn();
+    });
+
+    it("should clear session data when navigating away from the confirmation page", () => {
+        req.headers!.referer = `${CONFIRMATION}`;
+        req.query = {};
+
+        clearSessionAfterConfirmation(req as Request, res as Response, next);
+
+        expect(sessionMock.deleteExtraData).toHaveBeenCalledWith(USER_DATA);
+        expect(sessionMock.deleteExtraData).toHaveBeenCalledWith(CHECK_YOUR_ANSWERS_FLAG);
+        expect(next).toHaveBeenCalled();
+    });
+
+    it("should not clear session data when referer does not include the confirmation page", () => {
+        req.headers!.referer = `${PERSONS_NAME}`;
+
+        clearSessionAfterConfirmation(req as Request, res as Response, next);
+
+        expect(sessionMock.deleteExtraData).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalled();
+    });
+
+    it("should not clear session data when lang is switched on the confirmation page", () => {
+        req.headers!.referer = `${CONFIRMATION}`;
+        req.query = { lang: "cy" };
+
+        clearSessionAfterConfirmation(req as Request, res as Response, next);
+
+        expect(sessionMock.deleteExtraData).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2010

- When user clicks to go start page from banner link or clicked on authorised-agent from navbar and navigated back to Verify A Client service, the session data was not cleared.
- I added a new middleware to check for the confirmation page in the referrer which is where user is visiting from last and if it's confirmation screen then the session is cleared.
- If user clicks link to switch language then session is not cleared.