### PR TITLE
IDVA5-2005 Allow Option 1 passports to be used 6 months after expiry

### DIFF
--- a/locales/cy/id-document-details.json
+++ b/locales/cy/id-document-details.json
@@ -41,5 +41,7 @@
     "error-expiryDateNonNumeric": "Rhaid i {doc selected} cynnwys rhifau yn unig",
     "error-dateAfterIdChecksDone": "Rhaid i'r dyddiad dod i ben ar gyfer {doc selected} fod ar ôl {id checks completed} pan wnaethoch chi gwblhau'r gwiriadau hunaniaeth",
     "error-UK_biometric_residence_permit" : "Expiry date for {doc selected} cannot be more than 18 months before {id checks completed} when the identity checks were completed. Welsh",
+    "error-biometric_passport" : "Expiry date for {doc selected} cannot be more than 6 months before {id checks completed} when the identity checks were completed. Welsh",
+    "error-irish_passport_card" : "Expiry date for {doc selected} cannot be more than 6 months before {id checks completed} when the identity checks were completed. Welsh",
     "error-noCountry": "Dewiswch wlad ar gyfer {doc selected}"
 }

--- a/locales/en/id-document-details.json
+++ b/locales/en/id-document-details.json
@@ -41,5 +41,7 @@
     "error-expiryDateNonNumeric" : "{doc selected} must only include numbers",
     "error-dateAfterIdChecksDone" : "Expiry date for {doc selected} must be after {id checks completed} when you completed the identity checks",
     "error-UK_biometric_residence_permit" : "Expiry date for {doc selected} cannot be more than 18 months before {id checks completed} when the identity checks were completed.",
+    "error-biometric_passport" : "Expiry date for {doc selected} cannot be more than 6 months before {id checks completed} when the identity checks were completed.",
+    "error-irish_passport_card" : "Expiry date for {doc selected} cannot be more than 6 months before {id checks completed} when the identity checks were completed.",
     "error-noCountry" : "Choose a country for {doc selected}"
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -6,10 +6,15 @@ export const CHECK_YOUR_ANSWERS_FLAG = "checkYourAnswersFlag";
 export const ACSP_DETAILS = "acspDetails";
 export const BIOMETRIC_PASSPORT = "biometric_passport";
 export const PASSPORT = "passport";
-const BRP_GRACED_EXPIRY = 18;
 
+// ID Document Details for the extended expiry date exception
+const BRP_GRACED_EXPIRY_IN_MONTHS = 18;
+const BIOMETRIC_PASSPORT_GRACED_EXPIRY_IN_MONTHS = 6;
+const IRISH_PASSPORT_CARD_GRACED_EXPIRY_IN_MONTHS = 6;
 export const ID_DOCUMENTS_WITH_GRACED_EXPIRY = {
-    UK_biometric_residence_permit: BRP_GRACED_EXPIRY
+    UK_biometric_residence_permit: BRP_GRACED_EXPIRY_IN_MONTHS,
+    biometric_passport: BIOMETRIC_PASSPORT_GRACED_EXPIRY_IN_MONTHS,
+    irish_passport_card: IRISH_PASSPORT_CARD_GRACED_EXPIRY_IN_MONTHS
 };
 
 // Matomo


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2005

Added option 1 passports for the 6 months grace
-- Modified the constant for the new inclusion of the documents and their corresponding graced period.
-- Added the respective error messages.
-- Modified the constant names to be more meaningful.