### PR TITLE
Hiding Your companies link from navbar

### DIFF
--- a/src/views/partials/nav/top.njk
+++ b/src/views/partials/nav/top.njk
@@ -1,4 +1,5 @@
 {% from "navbar.njk" import addPredefinedNavbar %}
+
 {% set lang = i18n %}
 {# The last parameter of this navbar display function is used to determine if the 'Your companies' link should be displayed - setting this to 'no' until service is live #}
 {{ addPredefinedNavbar(userEmail, chsMonitorGuiUrl, lang, displayAuthorisedAgent, "no") }}

--- a/src/views/partials/nav/top.njk
+++ b/src/views/partials/nav/top.njk
@@ -1,3 +1,4 @@
 {% from "navbar.njk" import addPredefinedNavbar %}
 {% set lang = i18n %}
-{{ addPredefinedNavbar(userEmail, chsMonitorGuiUrl, lang, displayAuthorisedAgent, "yes") }}
+{# The last parameter of this navbar display function is used to determine if the 'Your companies' link should be displayed - setting this to 'no' until service is live #}
+{{ addPredefinedNavbar(userEmail, chsMonitorGuiUrl, lang, displayAuthorisedAgent, "no") }}


### PR DESCRIPTION
Change made for ticket:
[IDVA5-2036](https://companieshouse.atlassian.net/browse/IDVA5-2036)

- Hiding 'Your companies' link from common navbar until the service has gone live.
- This is conditionally set for the 'Your companies' navbar link

Please see PR for further details of the functionality:
[Navbar Conditional Item Display](https://github.com/companieshouse/ch-node-utils/pull/20/files)

[IDVA5-2036]: https://companieshouse.atlassian.net/browse/IDVA5-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ