### PR TITLE
IDVA5-2014 mobile-hidden class renamed to ul#navigation[hidden]

### DIFF
--- a/assets/src/scss/__global.scss
+++ b/assets/src/scss/__global.scss
@@ -143,7 +143,7 @@ ul#navigation li a {
     float: left;
     display: contents;
   }
-  .mobile-hidden {
+  ul#navigation[hidden] {
     display: none !important;
   }
 }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2014

mobile-hidden class was replaced with hidden html attribute so updating styling for ACSP to allow for navbar show/hide toggle.

.mobile-hidden replaced with ul#navigation[hidden]