### PR TITLE
[LIVE ISSUE] - Passport details sent as null to verification api

### DIFF
--- a/src/services/identityVerificationService.ts
+++ b/src/services/identityVerificationService.ts
@@ -99,7 +99,7 @@ export class IdentityVerificationService {
                 issuedBy: document.countryOfIssue
             } as VerificationEvidence;
         });
-        console.log("verificationEvidence", JSON.stringify(verificationEvidence));
+
         return {
             acspUserId: acspUserId,
             acspId: acspNumber,

--- a/src/services/identityVerificationService.ts
+++ b/src/services/identityVerificationService.ts
@@ -1,5 +1,5 @@
 import { Request } from "express";
-import { Identity, VerificationType, VerifiedClientData } from "private-api-sdk-node/dist/services/identity-verification/types";
+import { Identity, VerificationEvidence, VerificationType, VerifiedClientData } from "private-api-sdk-node/dist/services/identity-verification/types";
 import logger from "../utils/logger";
 import { Resource } from "@companieshouse/api-sdk-node";
 import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
@@ -88,13 +88,18 @@ export class IdentityVerificationService {
             preferredForeNames.push(clientData.preferredMiddleName!);
         }
 
-        const documentsChecked = clientData.documentsChecked!;
-        const verificationEvidence = documentsChecked.map((document) => {
+        const documentsChecked = clientData.idDocumentDetails!;
+        const verificationEvidence: VerificationEvidence[] = documentsChecked.map((document) => {
             // Map biometric_passport to passport to be accepted by Verification Api
-            const documentType = document === BIOMETRIC_PASSPORT ? PASSPORT : document;
-            return { type: documentType as unknown as VerificationType };
+            const documentType = document.docName === BIOMETRIC_PASSPORT ? PASSPORT : document.docName;
+            return {
+                type: documentType as unknown as VerificationType,
+                idNumber: document.documentNumber,
+                expiryDate: document.expiryDate,
+                issuedBy: document.countryOfIssue
+            } as VerificationEvidence;
         });
-
+        console.log("verificationEvidence", JSON.stringify(verificationEvidence));
         return {
             acspUserId: acspUserId,
             acspId: acspNumber,

--- a/test/mocks/identity.mock.ts
+++ b/test/mocks/identity.mock.ts
@@ -85,6 +85,15 @@ export const clientDetails = {
         postcode: "Postcode"
     },
     documentsChecked: ["passport"],
+    idDocumentDetails: [
+        {
+            docName: "passport",
+            documentNumber: "123456789",
+            expiryDate: new Date(),
+            countryOfIssue: "Country",
+            documentType: "passport"
+        }
+    ],
     emailAddress: "demo@ch.gov.uk",
     confirmEmailAddress: "demo@ch.gov.uk",
     howIdentityDocsChecked: "",
@@ -106,8 +115,17 @@ export const clientDetailsBiometricPassport = {
         propertyDetails: "Property Details"
     },
     documentsChecked: ["biometric_passport"],
+        idDocumentDetails: [
+        {
+            docName: "biometric_passport",
+            documentNumber: "123456789",
+            expiryDate: new Date(),
+            countryOfIssue: "Country",
+            documentType: "biometric_passport"
+        }
+    ],
     emailAddress: "john.doe@example.com",
     confirmEmailAddress: "john.doe@example.com",
     howIdentityDocsChecked: "",
-    whenIdentityChecksCompleted: new Date()
+    whenIdentityChecksCompleted: new Date("2028-02-25")
 };

--- a/test/src/services/identityVerificationService.test.ts
+++ b/test/src/services/identityVerificationService.test.ts
@@ -144,9 +144,16 @@ describe("verification api service tests", () => {
             const identityVerificationService = new IdentityVerificationService();
             const result = identityVerificationService.prepareVerifiedClientData(clientDetailsBiometricPassport, req);
 
-            expect(result.verificationEvidence).toEqual([
-                { type: "passport" }
-            ]);
+            expect(result.verificationEvidence).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        expiryDate: expect.anything(),
+                        idNumber: "123456789",
+                        issuedBy: "Country",
+                        type: "passport"
+                    })
+                ])
+            );
         });
     });
 });


### PR DESCRIPTION
The issue is due to verificationEvidence constant of the identityVerificationService.ts, which is formed only with the document type. Fixed the below:

- Modified ts to supply more details for the verificationEvidence along with the type.
- Modified the test cases.
- modified the mock