### PR TITLE
Include application name as the namespace within the service logs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -71,6 +71,11 @@ app.use(nocache());
 app.use(`^(${BASE_URL})$`, helmet(prepareCSPConfigHomePage(nonce)));
 app.use(`^(?!(${BASE_URL}$))*`, helmet(prepareCSPConfig(nonce)));
 
+app.use((req: Request, res: Response, next: NextFunction) => {
+    res.locals.nonce = nonce;
+    next();
+});
+
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, sessionMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, ensureSessionCookiePresentMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}|${BASE_URL}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, csrfProtectionMiddleware);
@@ -78,11 +83,6 @@ app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, acspAuthMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, acspIsActiveMiddleware);
 app.use(commonTemplateVariablesMiddleware);
-
-app.use((req: Request, res: Response, next: NextFunction) => {
-    res.locals.nonce = nonce;
-    next();
-});
 
 // Channel all requests through router dispatch
 routerDispatch(app);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,8 +1,15 @@
 import { createLogger } from "@companieshouse/structured-logging-node";
 import ApplicationLogger from "@companieshouse/structured-logging-node/lib/ApplicationLogger";
+import { APPLICATION_NAME } from "./properties";
 
-export const logger: ApplicationLogger = createLogger("acsp-confirm-client-id-verification-web");
-export default logger;
+let logger: ApplicationLogger;
+
+export const initLogger = (): ApplicationLogger => {
+    const applicationName = APPLICATION_NAME;
+    logger = createLogger(applicationName);
+    return logger;
+};
+export default initLogger();
 
 export const createAndLogError = (description: string): Error => {
     const error = new Error(description);

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -1,6 +1,6 @@
 import { getEnvironmentVariable, getEnvironmentValue } from "./environment/environment_value";
 
-export const APPLICATION_NAME = "acsp-confirm-client-id-verification-web";
+export const APPLICATION_NAME = getEnvironmentVariable("APPLICATION_NAME", "acsp-confirm-client-id-verification-web");
 
 // Hosts and URLS
 

--- a/test/src/setup.ts
+++ b/test/src/setup.ts
@@ -1,4 +1,4 @@
-process.env.APP_NAME = "acsp-confirm-client-id-verification-web";
+process.env.APPLICATION_NAME = "acsp-confirm-client-id-verification-web";
 process.env.LOG_LEVEL = "info";
 process.env.NODE_ENV = "dev";
 process.env.NODE_PORT = "3000";

--- a/test/src/utils/logger.test.ts
+++ b/test/src/utils/logger.test.ts
@@ -23,7 +23,7 @@ describe("logger tests", () => {
     });
 
     describe("initLogger", () => {
-        it("should create a logger with APP_NAME ", () => {
+        it("should create a logger with the web service application name", () => {
             const logger = initLoggerFn();
             expect(createLogger).toHaveBeenCalledWith("acsp-confirm-client-id-verification-web");
             expect(logger).toBe(mockLogger);

--- a/test/src/utils/logger.test.ts
+++ b/test/src/utils/logger.test.ts
@@ -1,24 +1,42 @@
-import ApplicationLogger from "@companieshouse/structured-logging-node/lib/ApplicationLogger";
-import { createAndLogError, logger } from "../../../src/utils/logger";
+import { createAndLogError, initLogger as initLoggerFn } from "../../../src/utils/logger";
+import { createLogger } from "@companieshouse/structured-logging-node";
 
 const ERROR_MESSAGE = "Error: Something went wrong";
 
-logger.error = jest.fn();
+jest.mock("@companieshouse/structured-logging-node", () => ({
+    createLogger: jest.fn()
+}));
+
+jest.mock("../../../src/utils/properties", () => ({
+    APPLICATION_NAME: "acsp-confirm-client-id-verification-web"
+}));
 
 describe("logger tests", () => {
+    const mockErrorFn = jest.fn();
+    const mockLogger = {
+        error: mockErrorFn
+    };
 
     beforeEach(() => {
         jest.clearAllMocks();
+        (createLogger as jest.Mock).mockReturnValue(mockLogger);
     });
 
-    test("Should test the logger object is defined of type ApplicationLogger", () => {
-        expect(logger).toBeDefined();
-        expect(logger).toBeInstanceOf(ApplicationLogger);
+    describe("initLogger", () => {
+        it("should create a logger with APP_NAME ", () => {
+            const logger = initLoggerFn();
+            expect(createLogger).toHaveBeenCalledWith("acsp-confirm-client-id-verification-web");
+            expect(logger).toBe(mockLogger);
+        });
     });
 
-    test("Should log and return an error", () => {
-        const err: Error = createAndLogError(ERROR_MESSAGE);
-        expect(err.message).toEqual(ERROR_MESSAGE);
-        expect(logger.error).toHaveBeenCalledTimes(1);
+    describe("createAndLogError", () => {
+        it("Should log and return an error", () => {
+            const err: Error = createAndLogError(ERROR_MESSAGE);
+            expect(err).toBeInstanceOf(Error);
+            expect(err.message).toEqual(ERROR_MESSAGE);
+            expect(mockErrorFn).toHaveBeenCalledTimes(1);
+            expect(mockErrorFn).toHaveBeenCalledWith(expect.stringContaining(ERROR_MESSAGE));
+        });
     });
 });


### PR DESCRIPTION
Changes made for ticket:
[IDVA5-2196](https://companieshouse.atlassian.net/browse/IDVA5-2196)

Following the same change process as PR for acsp-web: [PR869](https://github.com/companieshouse/acsp-web/pull/869)

- Updating logger util class to initiate the logger with the application name set to the namespace of the application (acsp-confirm-client-id-verification-web).
- Setting APPLICATION_NAME as an environment variable within properties.ts (this will default to the application name)
- Restructuring where the nonce value is set within app.ts (this is to allow inline scripts to run when an error is caught on application load - scripts used within the _footer.njk will now be called correctly when technical difficulties screen is rendered on application load)
- Updating unit tests

[IDVA5-2196]: https://companieshouse.atlassian.net/browse/IDVA5-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ