### PR TITLE
Update crown logo in header to King Charles III's

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "express-validator": "^6.14.0",
         "govuk_frontend_toolkit": "^9.0.1",
         "govuk-elements-sass": "^3.1.3",
-        "govuk-frontend": "^4.7.0",
+        "govuk-frontend": "^4.10.0",
         "helmet": "^8.0.0",
         "http-errors": "^1.7.3",
         "ioredis": "4.28.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "express-validator": "^6.14.0",
     "govuk_frontend_toolkit": "^9.0.1",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^4.7.0",
+    "govuk-frontend": "^4.10.0",
     "helmet": "^8.0.0",
     "http-errors": "^1.7.3",
     "ioredis": "4.28.5",

--- a/src/views/partials/__header.njk
+++ b/src/views/partials/__header.njk
@@ -6,7 +6,8 @@
     serviceUrl: serviceUrl or "/tell-companies-house-you-have-verified-someones-identity",
     serviceUrlAttributes: {
       id: "service-url-link"
-    }
+    },
+    useTudorCrown: true
   })
 }}
 <div class="govuk-width-container">


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2251?atlOrigin=eyJpIjoiMjliZDVmYzg5NDcxNDZmMDgwNWE3ZTNjZDgyN2NlZWUiLCJwIjoiaiJ9

Update Queen Elizabeth II's St. Edward's Crown logo to King Charles III's Tudor Crown.