### PR TITLE
Adding open in new tab text to IDV standard link

### DIFF
--- a/locales/cy/common.json
+++ b/locales/cy/common.json
@@ -8,5 +8,6 @@
     "AcceptAndContinue": "Derbyn a pharhau",
     "warning": "Rhybudd",
     "companiesHouseDoesNotVerify": "Nid yw Tŷ'r Cwmnïau yn gwirio cywirdeb y wybodaeth a ffeiliwyd",
-    "matomoPageTitle": "Dywedwch wrth Dŷ'r Cwmnïau eich bod wedi gwirio hunaniaeth rhywun - GOV.UK"
+    "matomoPageTitle": "Dywedwch wrth Dŷ'r Cwmnïau eich bod wedi gwirio hunaniaeth rhywun - GOV.UK",
+    "opensInANewTab": "yn agor mewn tab newydd"
 }

--- a/locales/cy/how-identity-documents-checked.json
+++ b/locales/cy/how-identity-documents-checked.json
@@ -2,7 +2,7 @@
     "howIdentityDocsCheckedTabTitle": "Dywedwch wrthym am y gwiriadau hunaniaeth rydych wedi'u cwblhau",
     "howIdentityDocsCheckedTitle": "Dywedwch wrthym am y gwiriadau hunaniaeth rydych wedi'u cwblhau",
     "howIdentityDocsCheckedBodyText1": "I wirio hunaniaeth rhywun ar gyfer Tŷ'r Cwmnïau, mae'n rhaid eich bod wedi cwblhau gwiriadau sy'n bodloni ein ",
-    "howIdentityDocsCheckedVerificationStandardLink": "safon gwiriad hunaniaeth",
+    "howIdentityDocsCheckedVerificationStandardLink": "safon gwiriad hunaniaeth ({OPENS_IN_NEW_TAB})",
     "howIdentityDocsCheckedBodyText2": "Mae 2 opsiwn ar gyfer gwirio dogfennau adnabod yn ein safon gwiriad hunaniaeth, bydd angen i chi ddweud wrthym.",
     "howIdentityDocsCheckedWhichOptionHeading": "Pa opsiwn o'r safon gwiriad hunaniaeth a ddefnyddiwyd gennych i wirio ei hunaniaeth?",
     "howIdentityDocsCheckedOption1": "Opsiwn 1",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -8,5 +8,6 @@
     "AcceptAndContinue": "Accept and Continue",
     "warning": "Warning",
     "companiesHouseDoesNotVerify": "Companies House does not verify the accuracy of the information filed",
-    "matomoPageTitle": " Tell Companies House you have verified someone’s identity - GOV.UK" 
+    "matomoPageTitle": " Tell Companies House you have verified someone’s identity - GOV.UK",
+    "opensInANewTab": "opens in a new tab"
 }

--- a/locales/en/how-identity-documents-checked.json
+++ b/locales/en/how-identity-documents-checked.json
@@ -2,7 +2,7 @@
     "howIdentityDocsCheckedTabTitle": "Tell us about the identity checks you completed",
     "howIdentityDocsCheckedTitle": "Tell us about the identity checks you completed",
     "howIdentityDocsCheckedBodyText1": "To verify someone's identity for Companies House, you must have completed checks that meet our ",
-    "howIdentityDocsCheckedVerificationStandardLink": "identity verification standard",
+    "howIdentityDocsCheckedVerificationStandardLink": "identity verification standard ({OPENS_IN_NEW_TAB})",
     "howIdentityDocsCheckedBodyText2": "There are 2 options for checking identity documents in the standard. You’ll need to tell us which option you used.",
     "howIdentityDocsCheckedWhichOptionHeading": "Which option from the identity verification standard did you use to verify their identity?",
     "howIdentityDocsCheckedOption1": "Option 1",

--- a/src/views/how-identity-documents-checked/how-identity-documents-checked.njk
+++ b/src/views/how-identity-documents-checked/how-identity-documents-checked.njk
@@ -12,7 +12,7 @@
     <div class="govuk-form-group">
         <h1 class="govuk-heading-l">{{ i18n.howIdentityDocsCheckedTitle }}</h1>
         <p class="govuk-body">
-            {{ i18n.howIdentityDocsCheckedBodyText1 }}<a target="_blank" href="https://www.gov.uk/guidance/how-to-meet-companies-house-identity-verification-standard" id="identity-verification-standard-link-id">{{ i18n.howIdentityDocsCheckedVerificationStandardLink }}</a>.
+            {{ i18n.howIdentityDocsCheckedBodyText1 }}<a target="_blank" href="https://www.gov.uk/guidance/how-to-meet-companies-house-identity-verification-standard" id="identity-verification-standard-link-id">{{ i18n.howIdentityDocsCheckedVerificationStandardLink | replace ("{OPENS_IN_NEW_TAB}", i18n.opensInANewTab) }}</a>.
         </p>
         <p class="govuk-body">{{ i18n.howIdentityDocsCheckedBodyText2 }}</p>
 


### PR DESCRIPTION
Changes for:
[IDVA5-2257](https://companieshouse.atlassian.net/browse/IDVA5-2257?atlOrigin=eyJpIjoiMDhlNjE5NWZlZDExNDIyZWJiZDE0MGIzMzA5YWY1MTIiLCJwIjoiaiJ9)

- Adding (opens in a new tab) text to external link as this opens in another tab

[IDVA5-2257]: https://companieshouse.atlassian.net/browse/IDVA5-2257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ