### PR TITLE
Move userIsPartOfAcspMiddleware to later stage when ACSP number is available

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -77,11 +77,11 @@ app.use((req: Request, res: Response, next: NextFunction) => {
     next();
 });
 
-app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, userIsPartOfAcspMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, sessionMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, ensureSessionCookiePresentMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}|${BASE_URL}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, csrfProtectionMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, authenticationMiddleware);
+app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, userIsPartOfAcspMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}$|${BASE_URL}${MUST_BE_AUTHORISED_AGENT}))*`, acspAuthMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}$|${BASE_URL}${MUST_BE_AUTHORISED_AGENT}))*`, acspIsActiveMiddleware);
 app.use(commonTemplateVariablesMiddleware);


### PR DESCRIPTION
**Short description outlining key changes/additions**

This PR is to fix the bug introduced in #261 
The issue it introduced was that users **who were** a part of an ACSP were being kicked out
This was because the new middleware was being called before the acsp number was being set in the session
I didn't test my changes against a valid user who is part of an ACSP and so missed this bug
This fix moves the middleware to a place where ACSP number has been populated in the session

**JIRA Ticket**

https://companieshouse.atlassian.net/browse/IDVA5-2031

**Type of change**
- [x] Bug fix
- [ ]  New feature
- [ ]  Breaking change
- [ ]  Infrastructure change

**Pull request checklist**
- [ ]  I have added unit tests for new code that I have added
- [ ]  I have added/updated functional tests where appropriate

**An exhaustive list of peer review checks can be read** [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)