### PR TITLE
Removing error text from start of events

### DIFF
--- a/src/views/partials/piwik.njk
+++ b/src/views/partials/piwik.njk
@@ -26,6 +26,13 @@
       //  It has to be defined under "analyticsWithCustomisedMatomoText()" function in the page where the customization is needed.
       if (!$.isFunction(window.analyticsWithCustomisedMatomoText)){
         var eventCategory = matomoObliteration($(document).find("title").text().split(' -')[0]);
+
+        if (eventCategory.startsWith("Error: ")){
+          eventCategory = eventCategory.replace("Error: ", "")
+        }
+        if (eventCategory.startsWith("Gwall: ")){
+          eventCategory = eventCategory.replace("Gwall: ", "")
+        }
  
         $("form").on("submit",function() {
           


### PR DESCRIPTION
Ticket [IDVA5-2336](https://companieshouse.atlassian.net/browse/IDVA5-2336)

Removing the 'Error: ' & 'Gwall: ' text from the start of events that occur on pages with previous errors

[IDVA5-2336]: https://companieshouse.atlassian.net/browse/IDVA5-2336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ