### PR TITLE
chore/cc-2723: use consistent env_var for public ALB

### DIFF
--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -4,7 +4,7 @@ export const APPLICATION_NAME = getEnvironmentVariable("APPLICATION_NAME", "acsp
 
 // Hosts and URLS
 
-export const ACCOUNT_URL = getEnvironmentVariable("ACCOUNT_LOCAL_URL", "false");
+export const ACCOUNT_URL = getEnvironmentVariable("ACCOUNT_URL", "false");
 
 export const API_URL = getEnvironmentValue("API_URL", "false");
 


### PR DESCRIPTION
Uses consistent env_var (`ACCOUNT_URL`) for public ALB