### PR TITLE
IDVA5-2497: Escaped name and preferredName in declaration strings

### DIFF
--- a/src/views/check-your-answers/check-your-answers.njk
+++ b/src/views/check-your-answers/check-your-answers.njk
@@ -26,7 +26,7 @@
     {% endif %}
     {% set fullPreferredName = fullPreferredName + ' ' + clientData.preferredLastName %}
   {% else %}
-    {% set fullPreferredName = fullName %}
+    {% set fullPreferredName = fullName | escape %}
   {% endif %}
 
   {% set identityChecksCompletedDate = clientData.whenIdentityChecksCompleted %}
@@ -41,9 +41,9 @@
     {% set howIdentityDocsChecked = i18n.option2Confirmation %}
   {% endif %}
 
-  {% set textContent = i18n.checkYourAnswersDeclarationText1 + " " + acspName + " " + i18n.checkYourAnswersDeclarationText2 + " " + fullName + i18n.checkYourAnswersDeclarationText3 %}
+  {% set textContent = i18n.checkYourAnswersDeclarationText1 + " " + acspName + " " + i18n.checkYourAnswersDeclarationText2 + " " + (fullName | escape) + i18n.checkYourAnswersDeclarationText3 %}
 
-  {% set verificationStatement1 = i18n.iConfirm + " " + acspName + " " + i18n.verifiedThe +  " " + fullName + " " + i18n.toTheStandard + " " + identityChecksCompletedDate + "." %}
+  {% set verificationStatement1 = i18n.iConfirm + " " + acspName + " " + i18n.verifiedThe +  " " + (fullName | escape) + " " + i18n.toTheStandard + " " + identityChecksCompletedDate + "." %}
 
   {% set verificationStatement2 = " " + acspName + " "  + i18n.isSupervised + "  " + amlBodies + "."%}
 

--- a/src/views/confirm-identity-verification/confirm-identity-verification.njk
+++ b/src/views/confirm-identity-verification/confirm-identity-verification.njk
@@ -6,17 +6,17 @@
 {% block main_content %}
 {% set displayedFirstName = " " %}
     {% if useNameOnPublicRegister == "use_name_on_public_register_no" %}
-        {% set displayedFirstName = preferredFirstName + " " %}
+        {% set displayedFirstName = (preferredFirstName | escape) + " " %}
     {% else %}   
-        {% set displayedFirstName = firstName  + " " %}
+        {% set displayedFirstName = (firstName | escape) + " " %}
     {% endif %}
 
 
 {% set displayedLastName = " " %}
     {% if useNameOnPublicRegister == "use_name_on_public_register_no" %}
-        {% set displayedLastName =  preferredLastName + " " %}
+        {% set displayedLastName =  (preferredLastName | escape) + " " %}
     {% else %}   
-        {% set displayedLastName =  lastName + " " %}
+        {% set displayedLastName =  (lastName | escape) + " " %}
     {% endif %}
 
 

--- a/src/views/confirmation/confirmation.njk
+++ b/src/views/confirmation/confirmation.njk
@@ -45,7 +45,7 @@
     {% set howIdentityDocsChecked = i18n.option2Confirmation %}
   {% endif %}
 
-  {% set verificationStatement1 = i18n.iConfirm + " " + acspName + " " + i18n.verifiedThe +  " " + fullName + " " + i18n.toTheStandard + " " + clientData.whenIdentityChecksCompleted + "." %}
+  {% set verificationStatement1 = i18n.iConfirm + " " + acspName + " " + i18n.verifiedThe +  " " + (fullName | escape) + " " + i18n.toTheStandard + " " + clientData.whenIdentityChecksCompleted + "." %}
 
   {% set verificationStatement2 = " " + acspName + " "  + i18n.isSupervised + "  " + amlBodies + "."%}
 


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2497

Bug fix: escaping name and preferredName within declaration strings when user input is e.g. `"<first> <middle> <last>"` to prevent empty values when incorrectly rendered as invalid html tags.

These are fixed in declaration screen, declaration string on Check Your Answers and declaration string in confirmation screen (including when printing details).