### PR TITLE
Escaping angle brackets to prevent issues when displaying on the front end views

### DIFF
--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -10,16 +10,16 @@ export class FormatService {
         if (address.propertyDetails || address.line1) {
             let combinedLine = "";
             if (address.propertyDetails) {
-                combinedLine += address.propertyDetails;
+                combinedLine += this.escapeHtml(address.propertyDetails);
             }
             if (address.line1) {
-                combinedLine += (combinedLine ? " " : "") + address.line1;
+                combinedLine += (combinedLine ? " " : "") + this.escapeHtml(address.line1);
             }
             parts.push(combinedLine);
         }
 
         if (address.line2) {
-            parts.push(address.line2);
+            parts.push(this.escapeHtml(address.line2));
         }
 
         if (address.town) {
@@ -35,7 +35,7 @@ export class FormatService {
         }
 
         if (address.postcode) {
-            parts.push(address.postcode);
+            parts.push(this.escapeHtml(address.postcode));
         }
 
         // Join the parts with `<br>` and return the formatted address
@@ -152,6 +152,23 @@ export class FormatService {
             }
         });
         return formattedDocuments;
+    }
+
+    /**
+     * Escapes HTML special characters to prevent XSS issues and ensure angle brackets are displayed correctly
+     * @param text The text to escape
+     * @returns Escaped HTML text
+     */
+    public static escapeHtml (text?: string): string {
+        if (!text) {
+            return "";
+        }
+        return text
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;");
     }
 
     public static formatDocumentHintText (documents: string[] | undefined, howIdentityDocsChecked: string | undefined, i18n: any): string[] {

--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -35,7 +35,7 @@ export class FormatService {
         }
 
         if (address.postcode) {
-            parts.push(this.escapeHtml(address.postcode));
+            parts.push(address.postcode);
         }
 
         // Join the parts with `<br>` and return the formatted address
@@ -154,21 +154,13 @@ export class FormatService {
         return formattedDocuments;
     }
 
-    /**
-     * Escapes HTML special characters to prevent XSS issues and ensure angle brackets are displayed correctly
-     * @param text The text to escape
-     * @returns Escaped HTML text
-     */
     public static escapeHtml (text?: string): string {
         if (!text) {
             return "";
         }
         return text
-            .replace(/&/g, "&amp;")
             .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&#039;");
+            .replace(/>/g, "&gt;");
     }
 
     public static formatDocumentHintText (documents: string[] | undefined, howIdentityDocsChecked: string | undefined, i18n: any): string[] {

--- a/src/validations/homeAddressManual.ts
+++ b/src/validations/homeAddressManual.ts
@@ -1,8 +1,8 @@
 import { body } from "express-validator";
 import { EXCLUDED_CHARS, LETTERS, NUMBERS, PUNCTUATION, SYMBOLS, WHITESPACE } from "./regexParts";
 
-const extemdedOtherAddressDetailsPattern = `^(?!.*[${EXCLUDED_CHARS}])[${LETTERS}${NUMBERS}${PUNCTUATION}${SYMBOLS}${WHITESPACE}]*$`;
-const extendedOtherAddressDetailsFormat:RegExp = new RegExp(extemdedOtherAddressDetailsPattern, "u");
+const extendedOtherAddressDetailsPattern = `^(?!.*[${EXCLUDED_CHARS}])[${LETTERS}${NUMBERS}${PUNCTUATION}${SYMBOLS}${WHITESPACE}]*$`;
+const extendedOtherAddressDetailsFormat:RegExp = new RegExp(extendedOtherAddressDetailsPattern, "u");
 const addressTownFormat:RegExp = /^[A-Za-z\-',\s!]*$/;
 const addressCountyAndCountryFormat:RegExp = /^[A-Za-z\-'\s]*$/;
 const addressUKPostcodeFormat:RegExp = /^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$/;

--- a/src/views/check-your-answers/check-your-answers.njk
+++ b/src/views/check-your-answers/check-your-answers.njk
@@ -41,11 +41,11 @@
     {% set howIdentityDocsChecked = i18n.option2Confirmation %}
   {% endif %}
 
-  {% set textContent = i18n.checkYourAnswersDeclarationText1 + " " + acspName + " " + i18n.checkYourAnswersDeclarationText2 + " " + (fullName | escape) + i18n.checkYourAnswersDeclarationText3 %}
+  {% set textContent = i18n.checkYourAnswersDeclarationText1 + " " + (acspName | escape) + " " + i18n.checkYourAnswersDeclarationText2 + " " + (fullName | escape) + i18n.checkYourAnswersDeclarationText3 %}
 
-  {% set verificationStatement1 = i18n.iConfirm + " " + acspName + " " + i18n.verifiedThe +  " " + (fullName | escape) + " " + i18n.toTheStandard + " " + identityChecksCompletedDate + "." %}
+  {% set verificationStatement1 = i18n.iConfirm + " " + (acspName | escape) + " " + i18n.verifiedThe +  " " + (fullName | escape) + " " + i18n.toTheStandard + " " + identityChecksCompletedDate + "." %}
 
-  {% set verificationStatement2 = " " + acspName + " "  + i18n.isSupervised + "  " + amlBodies + "."%}
+  {% set verificationStatement2 = " " + (acspName | escape) + " "  + i18n.isSupervised + "  " + amlBodies + "."%}
 
   {% set groupBDocs = [i18n.birth_certificate, i18n.marriage_certificate, i18n.immigration_document_non_photo_id, i18n.visa_non_photo_id, i18n.work_permit_non_photo_id, i18n.bank_statement, i18n.rental_agreement, i18n.mortgage_statement, i18n.UK_council_tax_statement, i18n.utility_bill] %}
 

--- a/src/views/confirm-identity-verification/confirm-identity-verification.njk
+++ b/src/views/confirm-identity-verification/confirm-identity-verification.njk
@@ -21,8 +21,8 @@
 
 
 
-{% set checkBoxText = "<p>" + i18n.confirmationStatement1 + " " + acspName + " " + i18n.confirmationStatement2 + " " + displayedFirstName + displayedLastName + i18n.confirmationStatement3 + " " + formattedDate + "." + 
-    "</p><br><p>" + i18n.Mae + acspName + " " + i18n.isSupervisedBy + " " + amlBodies + ".</p>"%}
+{% set checkBoxText = "<p>" + i18n.confirmationStatement1 + " " + (acspName | escape) + " " + i18n.confirmationStatement2 + " " + displayedFirstName + displayedLastName + i18n.confirmationStatement3 + " " + formattedDate + "." + 
+    "</p><br><p>" + i18n.Mae + (acspName | escape) + " " + i18n.isSupervisedBy + " " + amlBodies + ".</p>"%}
 
 {% include "partials/user_name.njk" %}
 <h1 class="govuk-heading-l">{{ i18n.confirmVerificationHeading }}</h1>

--- a/src/views/confirmation/confirmation.njk
+++ b/src/views/confirmation/confirmation.njk
@@ -45,9 +45,9 @@
     {% set howIdentityDocsChecked = i18n.option2Confirmation %}
   {% endif %}
 
-  {% set verificationStatement1 = i18n.iConfirm + " " + acspName + " " + i18n.verifiedThe +  " " + (fullName | escape) + " " + i18n.toTheStandard + " " + clientData.whenIdentityChecksCompleted + "." %}
+  {% set verificationStatement1 = i18n.iConfirm + " " + (acspName | escape) + " " + i18n.verifiedThe +  " " + (fullName | escape) + " " + i18n.toTheStandard + " " + clientData.whenIdentityChecksCompleted + "." %}
 
-  {% set verificationStatement2 = " " + acspName + " "  + i18n.isSupervised + "  " + amlBodies + "."%}
+  {% set verificationStatement2 = " " + (acspName | escape) + " "  + i18n.isSupervised + "  " + amlBodies + "."%}
 
   {% set groupBDocs = [i18n.birth_certificate, i18n.marriage_certificate, i18n.immigration_document_non_photo_id, i18n.visa_non_photo_id, i18n.work_permit_non_photo_id, i18n.bank_statement, i18n.rental_agreement, i18n.mortgage_statement, i18n.UK_council_tax_statement, i18n.utility_bill] %}
 

--- a/test/src/services/formatService.test.ts
+++ b/test/src/services/formatService.test.ts
@@ -51,29 +51,6 @@ describe("Format Service tests", () => {
             expect(result).toContain("Greater London");
             expect(result).toContain("United Kingdom");
         });
-
-        it("should join address parts with <br>", () => {
-            const address = {
-                propertyDetails: "Flat 1",
-                line1: "123 Main Street",
-                line2: "Area",
-                town: "London",
-                county: "Greater London",
-                country: "United Kingdom",
-                postcode: "SW1A 1AA"
-            };
-
-            const result = FormatService.formatAddress(address);
-            const parts = result.split("<br>");
-
-            expect(parts.length).toBe(6);
-            expect(parts[0]).toContain("Flat 1 123 Main Street");
-            expect(parts[1]).toBe("Area");
-            expect(parts[2]).toBe("London");
-            expect(parts[3]).toBe("Greater London");
-            expect(parts[4]).toBe("United Kingdom");
-            expect(parts[5]).toBe("SW1A 1AA");
-        });
     });
 
     describe("formatDocumentHintText tests", () => {

--- a/test/src/services/formatService.test.ts
+++ b/test/src/services/formatService.test.ts
@@ -3,6 +3,79 @@ import { CRYPTOGRAPHIC_SECURITY_FEATURES, PHYSICAL_SECURITY_FEATURES } from "../
 
 describe("Format Service tests", () => {
 
+    describe("escapeHtml tests", () => {
+        it("should return empty string when input is undefined", () => {
+            const result = FormatService.escapeHtml(undefined);
+            expect(result).toBe("");
+        });
+
+        it("should escape angle brackets", () => {
+            const result = FormatService.escapeHtml("<testAngleBrackets>");
+            expect(result).toBe("&lt;testAngleBrackets&gt;");
+        });
+
+        it("should not modify text without angle brackets", () => {
+            const result = FormatService.escapeHtml("Test no angle brackets");
+            expect(result).toBe("Test no angle brackets");
+        });
+
+        it("should handle multiple angle brackets", () => {
+            const result = FormatService.escapeHtml("<b>Some string data</b>");
+            expect(result).toBe("&lt;b&gt;Some string data&lt;/b&gt;");
+        });
+    });
+
+    describe("formatAddress tests", () => {
+        it("should handle undefined address", () => {
+            const result = FormatService.formatAddress(undefined);
+            expect(result).toBe("");
+        });
+
+        it("should escape HTML in address fields that may contain angle brackets but NOT in postcode", () => {
+            const address = {
+                propertyDetails: "Flat <A>",
+                line1: "<123> Main Street",
+                line2: "Suite <B>",
+                town: "London",
+                county: "Greater London",
+                country: "United Kingdom",
+                postcode: "SW1<1>AA"
+            };
+
+            const result = FormatService.formatAddress(address);
+
+            expect(result).toContain("Flat &lt;A&gt; &lt;123&gt; Main Street");
+            expect(result).toContain("Suite &lt;B&gt;");
+            expect(result).toContain("SW1<1>AA"); // Postcode should NOT be escaped
+            expect(result).toContain("London");
+            expect(result).toContain("Greater London");
+            expect(result).toContain("United Kingdom");
+        });
+
+        it("should join address parts with <br>", () => {
+            const address = {
+                propertyDetails: "Flat 1",
+                line1: "123 Main Street",
+                line2: "Area",
+                town: "London",
+                county: "Greater London",
+                country: "United Kingdom",
+                postcode: "SW1A 1AA"
+            };
+
+            const result = FormatService.formatAddress(address);
+            const parts = result.split("<br>");
+
+            expect(parts.length).toBe(6);
+            expect(parts[0]).toContain("Flat 1 123 Main Street");
+            expect(parts[1]).toBe("Area");
+            expect(parts[2]).toBe("London");
+            expect(parts[3]).toBe("Greater London");
+            expect(parts[4]).toBe("United Kingdom");
+            expect(parts[5]).toBe("SW1A 1AA");
+        });
+    });
+
     describe("formatDocumentHintText tests", () => {
 
         it("should return the hint text for option 1", () => {

--- a/test/src/services/formatService.test.ts
+++ b/test/src/services/formatService.test.ts
@@ -31,7 +31,7 @@ describe("Format Service tests", () => {
             expect(result).toBe("");
         });
 
-        it("should escape HTML in address fields that may contain angle brackets but NOT in postcode", () => {
+        it("should escape HTML in address fields that allow angle brackets", () => {
             const address = {
                 propertyDetails: "Flat <A>",
                 line1: "<123> Main Street",
@@ -39,14 +39,14 @@ describe("Format Service tests", () => {
                 town: "London",
                 county: "Greater London",
                 country: "United Kingdom",
-                postcode: "SW1<1>AA"
+                postcode: "SW1 1AA"
             };
 
             const result = FormatService.formatAddress(address);
 
             expect(result).toContain("Flat &lt;A&gt; &lt;123&gt; Main Street");
             expect(result).toContain("Suite &lt;B&gt;");
-            expect(result).toContain("SW1<1>AA"); // Postcode should NOT be escaped
+            expect(result).toContain("SW1 1AA");
             expect(result).toContain("London");
             expect(result).toContain("Greater London");
             expect(result).toContain("United Kingdom");


### PR DESCRIPTION
Changes for fixing bug:
[IDVA5-2530](https://companieshouse.atlassian.net/browse/IDVA5-2530)

As we are now accepting angle brackets as a valid input for the following address fields:
- Property name or number
- Address line 1
- Address line 2

We need to escape the angle brackets to ensure that are not rendered as html on the front end views.
Update made to the formatService file to escape only the above fields. This function was required as we need to have selective control of what should and should be escaped (i.e. We should not be escaping the Country field for example).

I have also included escaping at the view level for acspName (business name) as we now allow angle brackets as a valid input within this field.
If a company is named `<b>` or `<abc>` for example and accessed this service, then this was incorrectly rendering as html rather than the string value within the following screens:

- 'Confirm you have verified this person's identity' -> Declaration
- 'Check your answers' -> Identity verification declaration
- 'Check your answers' -> Declaration
- 'Confirmation screen' -> Identity verification declaration
- 'Confirmation screen' -> Declaration

Added unit tests

[IDVA5-2530]: https://companieshouse.atlassian.net/browse/IDVA5-2530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ