### PR TITLE
IDVA5-2548 Allow subdomains for gov.uk in CSP

### DIFF
--- a/src/middleware/content_security_policy_middleware_config.ts
+++ b/src/middleware/content_security_policy_middleware_config.ts
@@ -1,5 +1,5 @@
 import { HelmetOptions } from "helmet";
-import { CDN_HOST, PIWIK_URL, PIWIK_CHS_DOMAIN, CHS_URL } from "../utils/properties";
+import { CDN_HOST, PIWIK_URL, PIWIK_CHS_DOMAIN, CHS_URL, ENV_SUBDOMAIN } from "../utils/properties";
 
 const SELF = `'self'`;
 const ONE_YEAR_SECONDS = 31536000;
@@ -57,9 +57,14 @@ export const prepareCSPConfigHomePage = (nonce: string) : HelmetOptions => {
 };
 
 const formActionDirective = (ishomepage: boolean) => {
-    const ALL_CHS_URLS_SUBDOMAIN = "https://*.gov.uk";
+
     if (ishomepage) {
-        return [ALL_CHS_URLS_SUBDOMAIN];
+        return [
+            ENV_SUBDOMAIN,
+            SELF,
+            PIWIK_CHS_DOMAIN,
+            CHS_URL
+        ];
     } else {
         return [SELF, PIWIK_CHS_DOMAIN, CHS_URL];
     }

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -30,6 +30,8 @@ export const CDN_URL_JS = getEnvironmentValue("CDN_URL_JS", "false");
 
 export const POSTCODE_ADDRESSES_LOOKUP_URL = getEnvironmentVariable("POSTCODE_ADDRESSES_LOOKUP_URL", "false");
 
+export const ENV_SUBDOMAIN = getEnvironmentVariable("ENV_SUBDOMAIN", "false");
+
 // Misc Config
 
 export const LOCALES_ENABLED = getEnvironmentVariable("LOCALES_ENABLED", "true");


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2548

For testing, added subdomains of *.gov.uk and *.chdev.org (set in configs using ENV_SUBDOMAIN env variable) to see if this resolves zap testing risk that was raised (use of wildcard for all urls)