### PR TITLE
Updating start page link on 404 page for reverify service

### DIFF
--- a/locales/cy/error-pages.json
+++ b/locales/cy/error-pages.json
@@ -4,6 +4,7 @@
     "pageNotFoundText2": "Os gwnaethoch chi gludo'r cyfeiriad gwe, gwiriwch eich bod wedi copïo'r cyfeiriad cyfan.",
     "pageNotFoundText3": "Os yw'r cyfeiriad gwe yn gywir neu os ydych wedi dewis dolen, efallai bod y dudalen wedi symud. Ewch i'r ",
     "pageNotFoundLink": "Tudalen cychwyn dywedwch wrth Dŷ'r Cwmnïau eich bod wedi gwirio hunaniaeth rhywun",
+    "reverifyPageNotFoundLink": "Reverify someone's identity for Companies House start page - Welsh",
 
     "technicalDifficuliesTitle": "Mae'n ddrwg gennym ein bod yn profi anawsterau technegol",
     "technicalDifficuliesText1": "Ceisiwch eto mewn ychydig funudau.",

--- a/locales/en/error-pages.json
+++ b/locales/en/error-pages.json
@@ -4,6 +4,7 @@
     "pageNotFoundText2": "If you pasted the web address, check you copied the entire address.",
     "pageNotFoundText3": "If the web address is correct or you selected a link, the page may have moved. Go to the ",
     "pageNotFoundLink": "Tell Companies House you have verified someone’s identity start page",
+    "reverifyPageNotFoundLink": "Reverify someone's identity for Companies House start page",
 
     "technicalDifficuliesTitle": "Sorry we are experiencing technical difficulties",
     "technicalDifficuliesText1": "Try again in a few moments.",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -11,7 +11,7 @@ export const CEASED = "ceased";
 export const VERIFY_SERVICE_LINK = "verify-service-link";
 export const SERVICE_URL_LINK = "service-url-link";
 export const AUTHORISED_AGENT_ACCOUNT_LINK = "authorised-agent-account-link";
-export const REQ_TYPE_REVERIFY:string = "reverify";
+export const REQ_TYPE_REVERIFY: string = "reverify";
 // Matomo
 export const MATOMO_LINK_CLICK = "Click link";
 

--- a/src/views/partials/error_404.njk
+++ b/src/views/partials/error_404.njk
@@ -1,5 +1,13 @@
 {% extends "layouts/default.njk" %}
 
+{% if reqType == "reverify" %}
+  {% set serviceUrlLink = serviceUrl %}
+  {% set serviceNameBodyText = i18n.reverifyPageNotFoundLink %}
+{% else %}
+  {% set serviceUrlLink = serviceUrl %}
+  {% set serviceNameBodyText = i18n.pageNotFoundLink %}
+{% endif %}
+
 {% block backLink %}
   {# Remove back button on this page by replacing it with nothing #}
 {% endblock %}
@@ -11,6 +19,6 @@
   <p>{{ i18n.pageNotFoundText2 }}</p>
   <p>
       {{ i18n.pageNotFoundText3 }}
-      <a href="/tell-companies-house-you-have-verified-someones-identity">{{ i18n.pageNotFoundLink }}</a>.
+      <a href="{{ serviceUrlLink }}">{{ serviceNameBodyText }}</a>.
   </p>
 {% endblock %}	


### PR DESCRIPTION
Ticket:
[IDVA5-2636](https://companieshouse.atlassian.net/browse/IDVA5-2636)

- Updating body text link and associated body text on 404 page not found screen for the Reverification service.
- Body text link now dynamically displays as "Reverify someone's identity for Companies House start page" when hitting the page from the Reverification service and navigates the user back to the start page 

[IDVA5-2636]: https://companieshouse.atlassian.net/browse/IDVA5-2636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ