### PR TITLE
IDVA5-2493/2494: GOV.UK Rebrand - Install Latest  (ch-node-utils)

### DIFF
--- a/assets/src/scss/__global.scss
+++ b/assets/src/scss/__global.scss
@@ -1,6 +1,6 @@
 $govuk-global-styles: true;
 
-@import "node_modules/govuk-frontend/govuk/all";
+@import "node_modules/govuk-frontend/dist/govuk/base";
 
 * {
   font-family: "GDS Transport", Arial, sans-serif;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,7 +50,7 @@ gulp.task("js", () => {
 // Copy the fonts and images from the govuk-frontend package to the public directory
 gulp.task("govuk-assets", () => {
     return gulp
-        .src(["./node_modules/govuk-frontend/govuk/assets/**/*"])
+        .src(["./node_modules/govuk-frontend/dist/govuk/assets/**/*"])
         .pipe(gulp.dest(dstDirAssets));
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "express-validator": "^6.14.0",
         "govuk_frontend_toolkit": "^9.0.1",
         "govuk-elements-sass": "^3.1.3",
-        "govuk-frontend": "^4.10.0",
+        "govuk-frontend": "5.11.0",
         "helmet": "^8.0.0",
         "http-errors": "^1.7.3",
         "ioredis": "4.28.5",
@@ -8906,9 +8906,9 @@
       "license": "MIT"
     },
     "node_modules/govuk-frontend": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.10.1.tgz",
-      "integrity": "sha512-k7wKjPpLovQlfOiBt0A3RHQCpNagOR8xpfMgvTEQkX6Id5njYNzQTsBvpArDKAxI2174csv2uzn02py02zTVLA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.0.tgz",
+      "integrity": "sha512-RYZDEF1J6nVw5XauQGH+91qplExgHUXfXII7dtIme6I4u3eSvU59yZ0/EFKEwRgTslSqlhJODOnAi5rnQFU5Gw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "express-validator": "^6.14.0",
     "govuk_frontend_toolkit": "^9.0.1",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^4.10.0",
+    "govuk-frontend": "5.11.0",
     "helmet": "^8.0.0",
     "http-errors": "^1.7.3",
     "ioredis": "4.28.5",

--- a/src/app.ts
+++ b/src/app.ts
@@ -35,8 +35,8 @@ const app = express();
 const nonce: string = uuidv4();
 
 const nunjucksEnv = nunjucks.configure([path.join(__dirname, "views"),
-    path.join(__dirname, "/../node_modules/govuk-frontend"),
-    path.join(__dirname, "./node_modules/govuk-frontend"),
+    path.join(__dirname, "/../node_modules/govuk-frontend/dist"),
+    path.join(__dirname, "./node_modules/govuk-frontend/dist"),
     path.join(__dirname, "/../node_modules/@companieshouse/ch-node-utils/templates"),
     path.join(__dirname, "./node_modules/@companieshouse/ch-node-utils/templates"),
     path.join(__dirname, "/../../node_modules/@companieshouse/ch-node-utils/templates"),


### PR DESCRIPTION
**JIRA Ticket**
https://companieshouse.atlassian.net/browse/IDVA5-2493
https://companieshouse.atlassian.net/browse/IDVA5-2494

**Brief Description**
Following guide from ticket "[How to Enable the GOV.UK Rebrand in Node.js Web Applications](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/5479530596/How+to+Enable+the+GOV.UK+Rebrand+in+Node.js+Web+Applications)"

1. Update GOV.UK Frontend to Version 5.11.0
2. Adopt the Companies House Page Template (In Progress)
3. Update the GOV.UK header Component (To Do)
4. 