### PR TITLE
Updating inset text for confirm id reverifcation screen

### DIFF
--- a/locales/cy/confirm-identity-reverification.json
+++ b/locales/cy/confirm-identity-reverification.json
@@ -3,6 +3,7 @@
     "confirmReverificationWarningText": "We could suspend or stop {ACSP_NAME} from acting as an Authorised Corporate Service Provider (ACSP) if you have not met our identity verification standard. - Welsh",
     "identityVerificationStatement": "Identity verification statement - Welsh",
     "confirmationReverificationStatement": "I confirm that {ACSP_NAME} reverified the identity of {PERSON_NAME} to the standard set by Companies House and is satisfied that the required personal information is true. The reverification checks were completed on {REVERIFICATION_DATE}. - Welsh",
+    "reverifyShowThisDeclaration": "We will show this statement if this person uses their personal code to connect their verified identity to our records. - Welsh",
 
     "error-reverificationDeclarationNotChecked": "Select to confirm you have reverified their identity - Welsh"
 }

--- a/locales/en/confirm-identity-reverification.json
+++ b/locales/en/confirm-identity-reverification.json
@@ -3,6 +3,7 @@
     "confirmReverificationWarningText": "We could suspend or stop {ACSP_NAME} from acting as an Authorised Corporate Service Provider (ACSP) if you have not met our identity verification standard.",
     "identityVerificationStatement": "Identity verification statement",
     "confirmationReverificationStatement": "I confirm that {ACSP_NAME} reverified the identity of {PERSON_NAME} to the standard set by Companies House and is satisfied that the required personal information is true. The reverification checks were completed on {REVERIFICATION_DATE}.",
+    "reverifyShowThisDeclaration": "We will show this statement if this person uses their personal code to connect their verified identity to our records.",
 
     "error-reverificationDeclarationNotChecked": "Select to confirm you have reverified their identity"
 }

--- a/src/views/confirm-identity-verification/confirm-identity-verification.njk
+++ b/src/views/confirm-identity-verification/confirm-identity-verification.njk
@@ -21,6 +21,7 @@
         | replace('{PERSON_NAME}', personFullName) 
         | replace('{REVERIFICATION_DATE}', formattedDate) 
     %}
+    {% set showThisDeclarationInsetText = i18n.reverifyShowThisDeclaration %}
 {% else %}
     {% set title = i18n.confirmVerificationHeading %}
     {% set warningText = i18n.confirmVerificationWarningText | replace ('{ACSP_NAME}', acspName) %}
@@ -30,6 +31,7 @@
         | replace('{PERSON_NAME}', personFullName) 
         | replace('{VERIFICATION_DATE}', formattedDate) 
     %}
+    {% set showThisDeclarationInsetText = i18n.showThisDeclaration %}
 {% endif %}
 
 {% set checkBoxText = 
@@ -71,7 +73,7 @@
 
     <div class="govuk-inset-text">
         <h2 class="govuk-heading-m">{{ i18n.informationShownOnPublicRegister }}</h2>
-        <p class="govuk-body">{{ i18n.showThisDeclaration }}</p>
+        <p class="govuk-body">{{ showThisDeclarationInsetText }}</p>
     </div>
 
     {{ govukButton({


### PR DESCRIPTION
Update for ticket:
[IDVA5-2293](https://companieshouse.atlassian.net/browse/IDVA5-2293)

- Updating inset text for the following screen, in line with the latest prototype:
[Confirm you have reverified this person's identity](https://acsp-verify-identity-prototype.herokuapp.com/v1-reverify/id-check)

[IDVA5-2293]: https://companieshouse.atlassian.net/browse/IDVA5-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ