### PR TITLE
Developing choose an address screen reverify

### DIFF
--- a/locales/cy/address-list.json
+++ b/locales/cy/address-list.json
@@ -1,5 +1,6 @@
 {
     "addressListTitle": "Dewiswch gyfeiriad",
 
-    "error-addresListNoRadioBtnSelected" : "Dewiswch y cyfeiriad cartref"    
+    "error-addressListNoRadioBtnSelected" : "Dewiswch y cyfeiriad cartref",
+    "error-reverifyChooseAddressNoRadioBtnSelected" : "Select the correspondence address - Welsh" 
 }

--- a/locales/en/address-list.json
+++ b/locales/en/address-list.json
@@ -1,5 +1,6 @@
 {
     "addressListTitle": "Choose an address",
 
-    "error-addresListNoRadioBtnSelected" : "Select the home address"    
+    "error-addressListNoRadioBtnSelected" : "Select the home address",
+    "error-reverifyChooseAddressNoRadioBtnSelected" : "Select the correspondence address"  
 }

--- a/src/controllers/confirmHomeAddressController.ts
+++ b/src/controllers/confirmHomeAddressController.ts
@@ -3,7 +3,7 @@ import * as config from "../config";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { HOME_ADDRESS, BASE_URL, CONFIRM_HOME_ADDRESS, WHEN_IDENTITY_CHECKS_COMPLETED, HOME_ADDRESS_MANUAL, CHECK_YOUR_ANSWERS } from "../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { USER_DATA, MATOMO_LINK_CLICK, CHECK_YOUR_ANSWERS_FLAG } from "../utils/constants";
+import { USER_DATA, CHECK_YOUR_ANSWERS_FLAG } from "../utils/constants";
 import { ClientData } from "model/ClientData";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -18,7 +18,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             editPage: addLangToUrl(BASE_URL + HOME_ADDRESS_MANUAL, lang),
             ...getLocaleInfo(locales, lang),
             currentUrl: BASE_URL + CONFIRM_HOME_ADDRESS,
-            matomoLinkClick: MATOMO_LINK_CLICK,
             address: clientData?.address,
             firstName: clientData?.firstName,
             lastName: clientData?.lastName

--- a/src/controllers/confirmationController.ts
+++ b/src/controllers/confirmationController.ts
@@ -4,7 +4,7 @@ import { FormatService } from "../services/formatService";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
 import { CHECK_YOUR_ANSWERS, BASE_URL, CONFIRMATION, CONFIRMATION_REDIRECT } from "../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { ACSP_DETAILS, DATA_SUBMITTED_AND_EMAIL_SENT, MATOMO_LINK_CLICK, REFERENCE, USER_DATA } from "../utils/constants";
+import { ACSP_DETAILS, DATA_SUBMITTED_AND_EMAIL_SENT, REFERENCE, USER_DATA } from "../utils/constants";
 import { ClientData } from "../model/ClientData";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { getAmlBodiesAsString } from "../services/acspProfileService";
@@ -44,7 +44,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             reference,
             amlBodies,
             acspName: acspDetails.name,
-            matomoLinkClick: MATOMO_LINK_CLICK,
             feedbackSurveyLink: "https://www.smartsurvey.co.uk/s/tell-ch-verified-someones-id-conf/",
             verifyServiceLink: addLangToUrl(BASE_URL + CONFIRMATION_REDIRECT + "?id=verify-service-link", lang),
             authorisedAgentLink: addLangToUrl(BASE_URL + CONFIRMATION_REDIRECT + "?id=authorised-agent-account-link", lang),

--- a/src/controllers/homeAddressController.ts
+++ b/src/controllers/homeAddressController.ts
@@ -8,7 +8,7 @@ import { ValidationError, validationResult } from "express-validator";
 import { Session } from "@companieshouse/node-session-handler";
 import { ClientData } from "model/ClientData";
 import { AddressLookUpService } from "../services/addressLookup";
-import { USER_DATA, MATOMO_LINK_CLICK, PREVIOUS_PAGE_URL } from "../utils/constants";
+import { USER_DATA, PREVIOUS_PAGE_URL } from "../utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -33,7 +33,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             previousPage: previousPage,
             AddressManualLink: addLangToUrl(BASE_URL + HOME_ADDRESS_MANUAL, lang),
             currentUrl: BASE_URL + HOME_ADDRESS,
-            matomoLinkClick: MATOMO_LINK_CLICK,
             payload,
             firstName: clientData.firstName,
             lastName: clientData.lastName

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -27,17 +27,18 @@ export * as mustBeAnAuthorisedAgentController from "././mustBeAuthorisedAgentCon
 
 // reverify someones identity for companies house
 export * as reverifySomeonesIdentityController from "./reverify-someones-identity/indexController";
+export * as whatIsTheirPersonalCodeController from "./reverify-someones-identity/whatIsTheirPersonalCodeController";
+export * as reverifyPersonsEmailAddressController from "./reverify-someones-identity/reverifyPersonsEmailAddressController";
 export * as reverifyWhatIsThePersonsNameController from "./reverify-someones-identity/whatIsThePersonsNameController";
 export * as reverifyWhatWeShowOnPublicRegisterController from "./reverify-someones-identity/whatWeShowOnPublicRegisterController";
+export * as reverifyDateOfBirthController from "./reverify-someones-identity/dateOfBirthController";
 export * as nameOnVerificationStatementController from "./reverify-someones-identity/nameOnVerificationStatementController";
 export * as whatIsTheirHomeAddressController from "./reverify-someones-identity/whatIsTheirHomeAddressController";
-export * as reverifyDateOfBirthController from "./reverify-someones-identity/dateOfBirthController";
-export * as reverifyConfirmHomeAddressController from "./reverify-someones-identity/confirmHomeAddressController";
-export * as whatIsTheirPersonalCodeController from "./reverify-someones-identity/whatIsTheirPersonalCodeController";
-export * as identityDocumentsCheckedReverificationGroup2Controller from "./reverify-someones-identity/identityDocumentsCheckedReverificationGroup2Controller";
-export * as reverifyIdentityChecksCompletedController from "./reverify-someones-identity/reverifyIdentityChecksCompletedController";
-export * as reverifyPersonsEmailAddressController from "./reverify-someones-identity/reverifyPersonsEmailAddressController";
-export * as reverifyIdentityDocumentsCheckedGroup1Controller from "./reverify-someones-identity/identityDocumentsCheckedGroup1Controller";
-export * as reverifyHowIdentityDocumentsWereCheckedController from "./reverify-someones-identity/howIdentityDocumentsWereCheckedController";
 export * as reverifyHomeAddressManualController from "./reverify-someones-identity/homeAddressManualController";
+export * as reverifyChooseAnAddressController from "./reverify-someones-identity/chooseAnAddressController";
+export * as reverifyConfirmHomeAddressController from "./reverify-someones-identity/confirmHomeAddressController";
+export * as reverifyIdentityChecksCompletedController from "./reverify-someones-identity/reverifyIdentityChecksCompletedController";
+export * as reverifyHowIdentityDocumentsWereCheckedController from "./reverify-someones-identity/howIdentityDocumentsWereCheckedController";
+export * as reverifyIdentityDocumentsCheckedGroup1Controller from "./reverify-someones-identity/identityDocumentsCheckedGroup1Controller";
+export * as identityDocumentsCheckedReverificationGroup2Controller from "./reverify-someones-identity/identityDocumentsCheckedReverificationGroup2Controller";
 export * as reverifyConfirmIdentityReverificationController from "./reverify-someones-identity/confirmIdentityReverificationController";

--- a/src/controllers/indexController.ts
+++ b/src/controllers/indexController.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
 import { BASE_URL, PERSONS_NAME } from "../types/pageURL";
-import { CHECK_YOUR_ANSWERS_FLAG, MATOMO_LINK_CLICK, REFERENCE, USER_DATA } from "../utils/constants";
+import { CHECK_YOUR_ANSWERS_FLAG, REFERENCE, USER_DATA } from "../utils/constants";
 import {
     addLangToUrl,
     getLocaleInfo,
@@ -29,7 +29,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
         res.render(config.HOME, {
             ...getLocaleInfo(locales, lang),
-            matomoLinkClick: MATOMO_LINK_CLICK,
             PIWIK_START_GOAL_ID,
             currentUrl: BASE_URL
         });

--- a/src/controllers/reverify-someones-identity/chooseAnAddressController.ts
+++ b/src/controllers/reverify-someones-identity/chooseAnAddressController.ts
@@ -19,15 +19,14 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const session: Session = req.session as any as Session;
         const addressList = session.getExtraData(ADDRESS_LIST);
         const manualAddressLink: string = addLangToUrl(REVERIFY_BASE_URL + REVERIFY_HOME_ADDRESS_MANUAL, lang);
-
         const clientData: ClientData = session.getExtraData(USER_DATA) ? session.getExtraData(USER_DATA)! : {};
 
         res.render(config.HOME_ADDRESS_LIST, {
             ...getLocaleInfo(locales, lang),
-            currentUrl,
             previousPage,
-            addresses: addressList,
+            currentUrl,
             manualAddressLink,
+            addresses: addressList,
             firstname: clientData.firstName,
             lastname: clientData.lastName
         });
@@ -38,8 +37,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
+        const lang = selectLang(req.query.lang);
         const currentUrl: string = REVERIFY_BASE_URL + REVERIFY_CHOOSE_AN_ADDRESS;
         const errorList = validationResult(req);
         const previousPage: string = addLangToUrl(REVERIFY_BASE_URL + REVERIFY_WHAT_IS_THEIR_HOME_ADDRESS, lang);
@@ -52,20 +51,18 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
             res.status(400).render(config.HOME_ADDRESS_LIST, {
                 ...getLocaleInfo(locales, lang),
-                currentUrl,
+                pageProperties: pageProperties,
                 previousPage,
-                addresses: addressList,
+                currentUrl,
                 firstname: clientData.firstName,
                 lastname: clientData.lastName,
                 manualAddressLink,
-                pageProperties: pageProperties
+                addresses: addressList
             });
         } else {
             const selectPremise = req.body.homeAddress;
-
             // Save selected address to the session
             const homeAddress: Address = addressList.filter((address) => address.propertyDetails === selectPremise)[0];
-
             clientData.address = homeAddress;
             saveDataInSession(req, USER_DATA, clientData);
 

--- a/src/controllers/reverify-someones-identity/chooseAnAddressController.ts
+++ b/src/controllers/reverify-someones-identity/chooseAnAddressController.ts
@@ -1,24 +1,24 @@
 import { NextFunction, Request, Response } from "express";
-import * as config from "../config";
+import * as config from "../../config";
 import { validationResult } from "express-validator";
-import { formatValidationError, getPageProperties } from "../validations/validation";
-import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../utils/localise";
-import { HOME_ADDRESS_MANUAL, HOME_ADDRESS, BASE_URL, CHOOSE_AN_ADDRESS, CONFIRM_HOME_ADDRESS } from "../types/pageURL";
+import { formatValidationError, getPageProperties } from "../../validations/validation";
+import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../utils/localise";
+import { REVERIFY_HOME_ADDRESS_MANUAL, REVERIFY_WHAT_IS_THEIR_HOME_ADDRESS, REVERIFY_BASE_URL, REVERIFY_CHOOSE_AN_ADDRESS, REVERIFY_CONFIRM_HOME_ADDRESS } from "../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { ADDRESS_LIST, USER_DATA } from "../utils/constants";
+import { ADDRESS_LIST, USER_DATA } from "../../utils/constants";
 import { ClientData } from "model/ClientData";
 import { Address } from "model/Address";
-import { saveDataInSession } from "../utils/sessionHelper";
+import { saveDataInSession } from "../../utils/sessionHelper";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
-        const previousPage: string = addLangToUrl(BASE_URL + HOME_ADDRESS, lang);
-        const currentUrl: string = BASE_URL + CHOOSE_AN_ADDRESS;
+        const previousPage: string = addLangToUrl(REVERIFY_BASE_URL + REVERIFY_WHAT_IS_THEIR_HOME_ADDRESS, lang);
+        const currentUrl: string = REVERIFY_BASE_URL + REVERIFY_CHOOSE_AN_ADDRESS;
         const session: Session = req.session as any as Session;
         const addressList = session.getExtraData(ADDRESS_LIST);
-        const manualAddressLink: string = addLangToUrl(BASE_URL + HOME_ADDRESS_MANUAL, lang);
+        const manualAddressLink: string = addLangToUrl(REVERIFY_BASE_URL + REVERIFY_HOME_ADDRESS_MANUAL, lang);
 
         const clientData: ClientData = session.getExtraData(USER_DATA) ? session.getExtraData(USER_DATA)! : {};
 
@@ -40,13 +40,13 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
-        const currentUrl: string = BASE_URL + CHOOSE_AN_ADDRESS;
+        const currentUrl: string = REVERIFY_BASE_URL + REVERIFY_CHOOSE_AN_ADDRESS;
         const errorList = validationResult(req);
-        const previousPage: string = addLangToUrl(BASE_URL + HOME_ADDRESS, lang);
+        const previousPage: string = addLangToUrl(REVERIFY_BASE_URL + REVERIFY_WHAT_IS_THEIR_HOME_ADDRESS, lang);
         const session: Session = req.session as any as Session;
         const addressList: Address[] = session.getExtraData(ADDRESS_LIST)!;
         const clientData: ClientData = session.getExtraData(USER_DATA) ? session.getExtraData(USER_DATA)! : {};
-        const manualAddressLink: string = addLangToUrl(BASE_URL + HOME_ADDRESS_MANUAL, lang);
+        const manualAddressLink: string = addLangToUrl(REVERIFY_BASE_URL + REVERIFY_HOME_ADDRESS_MANUAL, lang);
 
         if (!errorList.isEmpty()) {
             const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
@@ -69,7 +69,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             clientData.address = homeAddress;
             saveDataInSession(req, USER_DATA, clientData);
 
-            const nextPageUrl = addLangToUrl(BASE_URL + CONFIRM_HOME_ADDRESS, lang);
+            const nextPageUrl = addLangToUrl(REVERIFY_BASE_URL + REVERIFY_CONFIRM_HOME_ADDRESS, lang);
             res.redirect(nextPageUrl);
         }
     } catch (error) {

--- a/src/controllers/reverify-someones-identity/confirmHomeAddressController.ts
+++ b/src/controllers/reverify-someones-identity/confirmHomeAddressController.ts
@@ -3,7 +3,7 @@ import * as config from "../../config";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../utils/localise";
 import { REVERIFY_BASE_URL, REVERIFY_HOME_ADDRESS_MANUAL, REVERIFY_CONFIRM_HOME_ADDRESS, REVERIFY_WHAT_IS_THEIR_HOME_ADDRESS, REVERIFY_CHECK_YOUR_ANSWERS, REVERIFY_WHEN_IDENTITY_CHECKS_COMPLETED } from "../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { USER_DATA, MATOMO_LINK_CLICK, CHECK_YOUR_ANSWERS_FLAG } from "../../utils/constants";
+import { USER_DATA, CHECK_YOUR_ANSWERS_FLAG } from "../../utils/constants";
 import { ClientData } from "model/ClientData";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -18,7 +18,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             currentUrl: REVERIFY_BASE_URL + REVERIFY_CONFIRM_HOME_ADDRESS,
             editPage: addLangToUrl(REVERIFY_BASE_URL + REVERIFY_HOME_ADDRESS_MANUAL, lang),
             previousPage: addLangToUrl(REVERIFY_BASE_URL + REVERIFY_WHAT_IS_THEIR_HOME_ADDRESS, lang),
-            matomoLinkClick: MATOMO_LINK_CLICK,
             firstName: clientData.firstName,
             lastName: clientData.lastName,
             address: clientData.address

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -70,7 +70,7 @@ routes.get(urls.HOME_ADDRESS_MANUAL, homeAddressManualController.get);
 routes.post(urls.HOME_ADDRESS_MANUAL, manualAddressValidator, homeAddressManualController.post);
 
 routes.get(urls.CHOOSE_AN_ADDRESS, addressListController.get);
-routes.post(urls.CHOOSE_AN_ADDRESS, addressListValidator, addressListController.post);
+routes.post(urls.CHOOSE_AN_ADDRESS, addressListValidator(), addressListController.post);
 
 routes.get(urls.DATE_OF_BIRTH, dateOfBirthController.get);
 routes.post(urls.DATE_OF_BIRTH, dateValidator("dob"), dateOfBirthController.post);

--- a/src/routers/reverifyRoutes.ts
+++ b/src/routers/reverifyRoutes.ts
@@ -15,7 +15,8 @@ import {
     reverifyIdentityChecksCompletedController,
     reverifyIdentityDocumentsCheckedGroup1Controller,
     reverifyConfirmIdentityReverificationController,
-    reverifyHowIdentityDocumentsWereCheckedController
+    reverifyHowIdentityDocumentsWereCheckedController,
+    reverifyChooseAnAddressController
 } from "../controllers";
 import { personalCodeValidator } from "../validations/personalCode";
 import { nameValidator } from "../validations/personName";
@@ -28,6 +29,7 @@ import { manualAddressValidator } from "../validations/homeAddressManual";
 import { identityDocsGroup2Validator } from "../validations/identityDocumentsGroup2";
 import { confirmIdentityReverificationValidator } from "../validations/confirmIdentityVerification";
 import { reverifyHowIdentityDocsCheckedValidator } from "../validations/howIdentityDocsChecked";
+import { addressListValidator } from "../validations/addressList";
 
 const reverifyRoutes = Router();
 
@@ -54,6 +56,9 @@ reverifyRoutes.post(urls.REVERIFY_WHAT_IS_THEIR_HOME_ADDRESS, homeAddressValidat
 
 reverifyRoutes.get(urls.REVERIFY_HOME_ADDRESS_MANUAL, reverifyHomeAddressManualController.get);
 reverifyRoutes.post(urls.REVERIFY_HOME_ADDRESS_MANUAL, manualAddressValidator, reverifyHomeAddressManualController.post);
+
+reverifyRoutes.get(urls.REVERIFY_CHOOSE_AN_ADDRESS, reverifyChooseAnAddressController.get);
+reverifyRoutes.post(urls.REVERIFY_CHOOSE_AN_ADDRESS, addressListValidator("reverify"), reverifyChooseAnAddressController.post);
 
 reverifyRoutes.get(urls.REVERIFY_CONFIRM_HOME_ADDRESS, reverifyConfirmHomeAddressController.get);
 reverifyRoutes.post(urls.REVERIFY_CONFIRM_HOME_ADDRESS, reverifyConfirmHomeAddressController.post);

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -97,8 +97,6 @@ export const REVERIFY_HOW_IDENTITY_DOCUMENTS_CHECKED = "/how-were-the-identity-d
 
 export const REVERIFY_PERSONS_EMAIL_ADDRESS = "/what-is-their-email-address";
 
-export const REVERIFY_IDENTITY_DOCUMENTS_CHECKED_GROUP2 = "/identity-documents-checked-group-2";
-
 export const REVERIFY_WHICH_IDENTITY_DOCS_CHECKED_GROUP1 = "/identity-documents-checked-using-technology";
 
 export const REVERIFY_WHICH_IDENTITY_DOCS_CHECKED_GROUP2 = "/identity-documents-checked";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,8 +12,6 @@ export const VERIFY_SERVICE_LINK = "verify-service-link";
 export const SERVICE_URL_LINK = "service-url-link";
 export const AUTHORISED_AGENT_ACCOUNT_LINK = "authorised-agent-account-link";
 export const REQ_TYPE_REVERIFY: string = "reverify";
-// Matomo
-export const MATOMO_LINK_CLICK = "Click link";
 
 // ID Document Details for the extended expiry date exceptions
 const GRACED_EXPIRY_OF_SIX_MONTHS = 6;

--- a/src/validations/addressList.ts
+++ b/src/validations/addressList.ts
@@ -1,5 +1,13 @@
 import { body } from "express-validator";
 
-export const addressListValidator = [
-    body("homeAddress", "addresListNoRadioBtnSelected").notEmpty()
+export const addressListValidator = (serviceName?: string) => [
+    body("homeAddress")
+        .notEmpty()
+        .withMessage(() => {
+            if (serviceName === "reverify") {
+                return "reverifyChooseAddressNoRadioBtnSelected";
+            } else {
+                return "addressListNoRadioBtnSelected";
+            }
+        })
 ];

--- a/test/src/controllers/reverify-somones-identity/chooseAnAddressController.test.ts
+++ b/test/src/controllers/reverify-somones-identity/chooseAnAddressController.test.ts
@@ -1,0 +1,55 @@
+import mocks from "../../../mocks/all_middleware_mock";
+import supertest from "supertest";
+import app from "../../../../src/app";
+import { REVERIFY_BASE_URL, REVERIFY_CONFIRM_HOME_ADDRESS, REVERIFY_CHOOSE_AN_ADDRESS } from "../../../../src/types/pageURL";
+import * as localise from "../../../../src/utils/localise";
+
+jest.mock("@companieshouse/api-sdk-node");
+
+const router = supertest(app);
+
+describe("GET" + REVERIFY_CHOOSE_AN_ADDRESS, () => {
+    it("should return status 200", async () => {
+        const res = await router.get(REVERIFY_BASE_URL + REVERIFY_CHOOSE_AN_ADDRESS);
+        expect(res.status).toBe(200);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+        expect(res.text).toContain("Choose an address");
+    });
+
+    it("should return status 500 if an error occurs", async () => {
+        jest.spyOn(localise, "getLocalesService").mockImplementationOnce(() => {
+            throw new Error("Test error");
+        });
+        const res = await router.get(REVERIFY_BASE_URL + REVERIFY_CHOOSE_AN_ADDRESS);
+        expect(res.status).toBe(500);
+        expect(res.text).toContain("Sorry we are experiencing technical difficulties");
+    });
+});
+
+describe("POST" + REVERIFY_CHOOSE_AN_ADDRESS, () => {
+
+    // Test for correct form details entered, will return 302.
+    it("should return status 302 and redirect to home address confirm screen", async () => {
+
+        const res = await router.post(REVERIFY_BASE_URL + REVERIFY_CHOOSE_AN_ADDRESS).send({ homeAddress: "1" });
+        expect(res.status).toBe(302);
+        expect(res.header.location).toBe(REVERIFY_BASE_URL + REVERIFY_CONFIRM_HOME_ADDRESS + "?lang=en");
+    });
+
+    // Test for incorrect form details entered, will return 400.
+    it("should return status 400 after incorrect data entered", async () => {
+        const res = await router.post(REVERIFY_BASE_URL + REVERIFY_CHOOSE_AN_ADDRESS).send({ homeAddress: "" });
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Select the correspondence address");
+    });
+
+    it("should return status 500 if an error occurs", async () => {
+        jest.spyOn(localise, "getLocalesService").mockImplementationOnce(() => {
+            throw new Error("Test error");
+        });
+        const res = await router.post(REVERIFY_BASE_URL + REVERIFY_CHOOSE_AN_ADDRESS);
+        expect(res.status).toBe(500);
+        expect(res.text).toContain("Sorry we are experiencing technical difficulties");
+    });
+});


### PR DESCRIPTION
Ticket:
[IDVA5-2645](https://companieshouse.atlassian.net/browse/IDVA5-2645)

- Developing choose address screen for Reverify service
- Creating controller and adding routing and configs
- Adding Validation error message for when no radio option is selected
- Removing the Matomo variable calls as this is no longer used within the repo
- Adding unit tests

[IDVA5-2645]: https://companieshouse.atlassian.net/browse/IDVA5-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ