### PR TITLE
IDVA5-2641 Kickout screen for invalid personal code

### DIFF
--- a/locales/cy/reverify-invalid-personal-code.json
+++ b/locales/cy/reverify-invalid-personal-code.json
@@ -1,0 +1,4 @@
+{
+    "reverifyInvalidPersonalCodeTitle": "[PLACEHOLDER] Personal code is not valid pending reverification - Welsh",
+    "reverifyInvalidPersonalCodeBody": "[PLACEHOLDER] Personal code is not valid pending reverification - Welsh"
+}

--- a/locales/en/reverify-invalid-personal-code.json
+++ b/locales/en/reverify-invalid-personal-code.json
@@ -1,0 +1,4 @@
+{
+    "reverifyInvalidPersonalCodeTitle": "[PLACEHOLDER] Personal code is not valid pending reverification",
+    "reverifyInvalidPersonalCodeBody": "[PLACEHOLDER] Personal code is not valid pending reverification"
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -42,3 +42,4 @@ export const REVERIFY_HOME = `${BASE_REVERIFY_URL}/index/home`;
 export const REVERIFY_WHAT_WE_SHOW_ON_PUBLIC_REGISTER = `${BASE_REVERIFY_URL}/what-we-show-on-public-register/what-we-show-on-public-register`;
 export const REVERIFY_PERSONAL_CODE = `${BASE_REVERIFY_URL}/personal-code/personal-code`;
 export const REVERIFY_CHECK_YOUR_ANSWERS = `${BASE_REVERIFY_URL}/check-your-answers/check-your-answers`;
+export const REVERIFY_INVALID_PERSONAL_CODE = `${BASE_REVERIFY_URL}/reverify-invalid-personal-code/reverify-invalid-personal-code`;

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -44,3 +44,4 @@ export * as reverifyHomeAddressManualController from "./reverify-someones-identi
 export * as reverifyChooseAnAddressController from "./reverify-someones-identity/chooseAnAddressController";
 export * as reverifyConfirmIdentityReverificationController from "./reverify-someones-identity/confirmIdentityReverificationController";
 export * as reverifyCheckYourAnswersController from "./reverify-someones-identity/checkYourAnswersController";
+export * as reverifyInvalidPersonalCodeController from "./reverify-someones-identity/reverifyInvalidPersonalCodeController";

--- a/src/controllers/reverify-someones-identity/reverifyInvalidPersonalCodeController.ts
+++ b/src/controllers/reverify-someones-identity/reverifyInvalidPersonalCodeController.ts
@@ -1,0 +1,19 @@
+import { NextFunction, Request, Response } from "express";
+import * as config from "../../config";
+import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../utils/localise";
+import { REVERIFY_BASE_URL, REVERIFY_PERSONAL_CODE, REVERIFY_PERSONAL_CODE_IS_INVALID } from "../../types/pageURL";
+
+export const get = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lang = selectLang(req.query.lang);
+        const locales = getLocalesService();
+
+        res.render(config.REVERIFY_INVALID_PERSONAL_CODE, {
+            ...getLocaleInfo(locales, lang),
+            currentUrl: REVERIFY_BASE_URL + REVERIFY_PERSONAL_CODE_IS_INVALID,
+            previousPage: addLangToUrl(REVERIFY_BASE_URL + REVERIFY_PERSONAL_CODE, lang)
+        });
+    } catch (error) {
+        next(error);
+    }
+};

--- a/src/routers/reverifyRoutes.ts
+++ b/src/routers/reverifyRoutes.ts
@@ -18,7 +18,8 @@ import {
     reverifyConfirmIdentityReverificationController,
     reverifyHowIdentityDocumentsWereCheckedController,
     reverifyChooseAnAddressController,
-    reverifyCheckYourAnswersController
+    reverifyCheckYourAnswersController,
+    reverifyInvalidPersonalCodeController
 } from "../controllers";
 import { personalCodeValidator } from "../validations/personalCode";
 import { nameValidator } from "../validations/personName";
@@ -90,5 +91,7 @@ reverifyRoutes.post(urls.REVERIFY_CONFIRM_IDENTITY_REVERIFICATION, confirmIdenti
 
 reverifyRoutes.get(urls.CHECK_YOUR_ANSWERS, reverifyCheckYourAnswersController.get);
 reverifyRoutes.post(urls.CHECK_YOUR_ANSWERS, checkYourAnswerValidator, reverifyCheckYourAnswersController.post);
+
+reverifyRoutes.get(urls.REVERIFY_PERSONAL_CODE_IS_INVALID, reverifyInvalidPersonalCodeController.get);
 
 export default reverifyRoutes;

--- a/src/views/reverify-someones-identity/reverify-invalid-personal-code/reverify-invalid-personal-code.njk
+++ b/src/views/reverify-someones-identity/reverify-invalid-personal-code/reverify-invalid-personal-code.njk
@@ -1,0 +1,7 @@
+{% extends "layouts/default.njk" %}
+{% set title = i18n.reverifyInvalidPersonalCodeTitle %}
+
+{% block main_content %}
+    <h1 class="govuk-heading-l">{{ i18n.reverifyInvalidPersonalCodeTitle }}</h1>
+    <p class="govuk-body">{{ i18n.reverifyInvalidPersonalCodeBody }}</p>
+{% endblock main_content %}

--- a/test/src/controllers/reverify-somones-identity/reverifyInvalidPersonalCodeController.test.ts
+++ b/test/src/controllers/reverify-somones-identity/reverifyInvalidPersonalCodeController.test.ts
@@ -1,0 +1,27 @@
+import mocks from "../../../mocks/all_middleware_mock";
+import supertest from "supertest";
+import app from "../../../../src/app";
+import { REVERIFY_BASE_URL, REVERIFY_PERSONAL_CODE_IS_INVALID } from "../../../../src/types/pageURL";
+import * as localise from "../../../../src/utils/localise";
+
+const router = supertest(app);
+
+describe("GET " + REVERIFY_PERSONAL_CODE_IS_INVALID, () => {
+    it("should respond with status 200", async () => {
+        const res = await router.get(REVERIFY_BASE_URL + REVERIFY_PERSONAL_CODE_IS_INVALID);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        expect(res.text).toContain("[PLACEHOLDER]");
+    });
+
+    it("should show the error page if an error occurs", async () => {
+        const errorMessage = "Test error";
+        jest.spyOn(localise, "getLocalesService").mockImplementationOnce(() => {
+            throw new Error(errorMessage);
+        });
+        const res = await router.get(REVERIFY_BASE_URL + REVERIFY_PERSONAL_CODE_IS_INVALID);
+        expect(res.status).toBe(500);
+        expect(res.text).toContain("Sorry we are experiencing technical difficulties");
+    });
+});


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2641

<img width="1005" height="490" alt="Screenshot 2025-09-17 at 15 11 20" src="https://github.com/user-attachments/assets/460ce012-684c-4efe-b2cb-da260a5eb73a" />

- Added new view for kickout screen using placeholder content in en/cy locales files
- New controller to render the view and set back link to personal code screen
- Routing and config changes
- Unit test class added for coverage
