### PR TITLE
Updating validation error message to reflect what we have for verify service

### DIFF
--- a/locales/cy/address-list.json
+++ b/locales/cy/address-list.json
@@ -1,6 +1,5 @@
 {
     "addressListTitle": "Dewiswch gyfeiriad",
 
-    "error-addressListNoRadioBtnSelected" : "Dewiswch y cyfeiriad cartref",
-    "error-reverifyChooseAddressNoRadioBtnSelected" : "Select the correspondence address - Welsh" 
+    "error-addressListNoRadioBtnSelected" : "Dewiswch y cyfeiriad cartref"
 }

--- a/locales/en/address-list.json
+++ b/locales/en/address-list.json
@@ -1,6 +1,5 @@
 {
     "addressListTitle": "Choose an address",
 
-    "error-addressListNoRadioBtnSelected" : "Select the home address",
-    "error-reverifyChooseAddressNoRadioBtnSelected" : "Select the correspondence address"  
+    "error-addressListNoRadioBtnSelected" : "Select the home address"
 }

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -70,7 +70,7 @@ routes.get(urls.HOME_ADDRESS_MANUAL, homeAddressManualController.get);
 routes.post(urls.HOME_ADDRESS_MANUAL, manualAddressValidator, homeAddressManualController.post);
 
 routes.get(urls.CHOOSE_AN_ADDRESS, addressListController.get);
-routes.post(urls.CHOOSE_AN_ADDRESS, addressListValidator(), addressListController.post);
+routes.post(urls.CHOOSE_AN_ADDRESS, addressListValidator, addressListController.post);
 
 routes.get(urls.DATE_OF_BIRTH, dateOfBirthController.get);
 routes.post(urls.DATE_OF_BIRTH, dateValidator("dob"), dateOfBirthController.post);

--- a/src/routers/reverifyRoutes.ts
+++ b/src/routers/reverifyRoutes.ts
@@ -63,7 +63,7 @@ reverifyRoutes.get(urls.REVERIFY_HOME_ADDRESS_MANUAL, reverifyHomeAddressManualC
 reverifyRoutes.post(urls.REVERIFY_HOME_ADDRESS_MANUAL, manualAddressValidator, reverifyHomeAddressManualController.post);
 
 reverifyRoutes.get(urls.REVERIFY_CHOOSE_AN_ADDRESS, reverifyChooseAnAddressController.get);
-reverifyRoutes.post(urls.REVERIFY_CHOOSE_AN_ADDRESS, addressListValidator("reverify"), reverifyChooseAnAddressController.post);
+reverifyRoutes.post(urls.REVERIFY_CHOOSE_AN_ADDRESS, addressListValidator, reverifyChooseAnAddressController.post);
 
 reverifyRoutes.get(urls.REVERIFY_CONFIRM_HOME_ADDRESS, reverifyConfirmHomeAddressController.get);
 reverifyRoutes.post(urls.REVERIFY_CONFIRM_HOME_ADDRESS, reverifyConfirmHomeAddressController.post);

--- a/src/validations/addressList.ts
+++ b/src/validations/addressList.ts
@@ -1,13 +1,5 @@
 import { body } from "express-validator";
 
-export const addressListValidator = (serviceName?: string) => [
-    body("homeAddress")
-        .notEmpty()
-        .withMessage(() => {
-            if (serviceName === "reverify") {
-                return "reverifyChooseAddressNoRadioBtnSelected";
-            } else {
-                return "addressListNoRadioBtnSelected";
-            }
-        })
+export const addressListValidator = [
+    body("homeAddress", "addressListNoRadioBtnSelected").notEmpty()
 ];

--- a/test/src/controllers/reverify-somones-identity/chooseAnAddressController.test.ts
+++ b/test/src/controllers/reverify-somones-identity/chooseAnAddressController.test.ts
@@ -41,7 +41,7 @@ describe("POST" + REVERIFY_CHOOSE_AN_ADDRESS, () => {
     it("should return status 400 after incorrect data entered", async () => {
         const res = await router.post(REVERIFY_BASE_URL + REVERIFY_CHOOSE_AN_ADDRESS).send({ homeAddress: "" });
         expect(res.status).toBe(400);
-        expect(res.text).toContain("Select the correspondence address");
+        expect(res.text).toContain("Select the home address");
     });
 
     it("should return status 500 if an error occurs", async () => {


### PR DESCRIPTION
Fix for ticket:
[IDVA5-2645](https://companieshouse.atlassian.net/browse/IDVA5-2645)

- Updating validation error message content for 'Choose an address' screen on Reverify service, as we want this to match the current validation message we use for this screen on the Verify service

[IDVA5-2645]: https://companieshouse.atlassian.net/browse/IDVA5-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ