### PR TITLE
Update suspended page for reverify journey, add controller, update ro…

### DIFF
--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -44,5 +44,6 @@ export * as reverifyHomeAddressManualController from "./reverify-someones-identi
 export * as reverifyChooseAnAddressController from "./reverify-someones-identity/chooseAnAddressController";
 export * as reverifyConfirmIdentityReverificationController from "./reverify-someones-identity/confirmIdentityReverificationController";
 export * as reverifyCheckYourAnswersController from "./reverify-someones-identity/checkYourAnswersController";
+export * as reverifyCannotUseServiceWhileSuspendedController from "./reverify-someones-identity/cannotUseServiceWhileSuspendedController";
 export * as reverifyInvalidPersonalCodeController from "./reverify-someones-identity/reverifyInvalidPersonalCodeController";
 export * as reverifyMustBeAuthorisedAgentController from "./reverify-someones-identity/mustBeAuthorisedAgentController";

--- a/src/controllers/reverify-someones-identity/cannotUseServiceWhileSuspendedController.ts
+++ b/src/controllers/reverify-someones-identity/cannotUseServiceWhileSuspendedController.ts
@@ -1,0 +1,25 @@
+import { NextFunction, Request, Response } from "express";
+import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../utils/localise";
+import * as config from "../../config";
+import { Session } from "@companieshouse/node-session-handler";
+import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
+import { ACSP_DETAILS } from "../../utils/constants";
+import { AUTHORISED_AGENT, REVERIFY_BASE_URL, REVERIFY_CANNOT_USE_SERVICE_WHILE_SUSPENDED } from "../../types/pageURL";
+
+export const get = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lang = selectLang(req.query.lang);
+        const locales = getLocalesService();
+        const session: Session = req.session as any as Session;
+        const acspDetails: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
+
+        res.render(config.CANNOT_USE_SERVICE_WHILE_SUSPENDED, {
+            ...getLocaleInfo(locales, lang),
+            currentUrl: REVERIFY_BASE_URL + REVERIFY_CANNOT_USE_SERVICE_WHILE_SUSPENDED,
+            businessName: acspDetails.name,
+            authorisedAgentLink: addLangToUrl(AUTHORISED_AGENT, lang)
+        });
+    } catch (error) {
+        next(error);
+    }
+};

--- a/src/middleware/acsp_is_active_middleware.ts
+++ b/src/middleware/acsp_is_active_middleware.ts
@@ -6,7 +6,7 @@ import { ACSP_DETAILS, ACTIVE_STATUS } from "../utils/constants";
 import { Session } from "@companieshouse/node-session-handler";
 import { InvalidAcspNumberError } from "@companieshouse/web-security-node";
 import { addLangToUrl, selectLang } from "../utils/localise";
-import { BASE_URL, CANNOT_USE_SERVICE_WHILE_SUSPENDED } from "../types/pageURL";
+import { BASE_URL, CANNOT_USE_SERVICE_WHILE_SUSPENDED, REVERIFY_BASE_URL, REVERIFY_CANNOT_USE_SERVICE_WHILE_SUSPENDED } from "../types/pageURL";
 
 export const acspIsActiveMiddleware = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -21,10 +21,11 @@ export const acspIsActiveMiddleware = async (req: Request, res: Response, next: 
         }
 
         if (acspDetails.status === "suspended") {
-            if (req.originalUrl.includes(CANNOT_USE_SERVICE_WHILE_SUSPENDED)) {
-                return next();
-            } else {
-                res.redirect(addLangToUrl(BASE_URL + CANNOT_USE_SERVICE_WHILE_SUSPENDED, lang));
+            const isReverifyService: boolean = req.originalUrl.includes(REVERIFY_BASE_URL);
+            const cannotUseThisServiceWhileSuspendedUrl = isReverifyService ? REVERIFY_CANNOT_USE_SERVICE_WHILE_SUSPENDED : CANNOT_USE_SERVICE_WHILE_SUSPENDED;
+            const baseUrl = isReverifyService ? REVERIFY_BASE_URL : BASE_URL;
+            if (!req.originalUrl.includes(cannotUseThisServiceWhileSuspendedUrl)) {
+                res.redirect(addLangToUrl(baseUrl + cannotUseThisServiceWhileSuspendedUrl, lang));
                 return;
             }
         } else if (acspDetails.status !== ACTIVE_STATUS) {

--- a/src/routers/reverifyRoutes.ts
+++ b/src/routers/reverifyRoutes.ts
@@ -20,7 +20,8 @@ import {
     reverifyChooseAnAddressController,
     reverifyCheckYourAnswersController,
     reverifyInvalidPersonalCodeController,
-    reverifyMustBeAuthorisedAgentController
+    reverifyMustBeAuthorisedAgentController,
+    reverifyCannotUseServiceWhileSuspendedController
 } from "../controllers";
 import { personalCodeValidator } from "../validations/personalCode";
 import { nameValidator } from "../validations/personName";
@@ -96,5 +97,7 @@ reverifyRoutes.post(urls.CHECK_YOUR_ANSWERS, checkYourAnswerValidator, reverifyC
 reverifyRoutes.get(urls.REVERIFY_PERSONAL_CODE_IS_INVALID, reverifyInvalidPersonalCodeController.get);
 
 reverifyRoutes.get(urls.REVERIFY_MUST_BE_AUTHORISED_AGENT, reverifyMustBeAuthorisedAgentController.get);
+
+reverifyRoutes.get(urls.REVERIFY_CANNOT_USE_SERVICE_WHILE_SUSPENDED, reverifyCannotUseServiceWhileSuspendedController.get);
 
 export default reverifyRoutes;

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -109,4 +109,6 @@ export const REVERIFY_CHECK_YOUR_ANSWERS = "/check-your-answers";
 
 export const REVERIFY_CONFIRMATION = "/confirmation";
 
+export const REVERIFY_CANNOT_USE_SERVICE_WHILE_SUSPENDED = "/cannot-use-service-while-suspended";
+
 export const REVERIFY_MUST_BE_AUTHORISED_AGENT = "/must-be-authorised-agent";

--- a/test/src/controllers/reverify-somones-identity/cannotUseServiceWhileSuspendedController.test.ts
+++ b/test/src/controllers/reverify-somones-identity/cannotUseServiceWhileSuspendedController.test.ts
@@ -1,0 +1,25 @@
+import mocks from "../../../mocks/all_middleware_mock";
+import supertest from "supertest";
+import app from "../../../../src/app";
+import { REVERIFY_BASE_URL, REVERIFY_CANNOT_USE_SERVICE_WHILE_SUSPENDED } from "../../../../src/types/pageURL";
+import * as localise from "../../../../src/utils/localise";
+
+const router = supertest(app);
+
+describe("GET" + REVERIFY_CANNOT_USE_SERVICE_WHILE_SUSPENDED, () => {
+    it("should render the confirmation page with status 200 ans display the information on the screen", async () => {
+        const res = await router.get(REVERIFY_BASE_URL + REVERIFY_CANNOT_USE_SERVICE_WHILE_SUSPENDED);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        expect(res.text).toContain("You cannot use this service while the authorised agent is suspended");
+    });
+
+    it("should return status 500 if an error occurs", async () => {
+        jest.spyOn(localise, "getLocalesService").mockImplementationOnce(() => {
+            throw new Error("Test error");
+        });
+        const res = await router.get(REVERIFY_BASE_URL + REVERIFY_CANNOT_USE_SERVICE_WHILE_SUSPENDED);
+        expect(res.status).toBe(500);
+        expect(res.text).toContain("Sorry we are experiencing technical difficulties");
+    });
+});


### PR DESCRIPTION
Ticket: https://companieshouse.atlassian.net/browse/IDVA5-2551?atlOrigin=eyJpIjoiMDgzMDM1ZjFkZWExNDc1MTk2MmI0MzcwMjdhY2IwMGUiLCJwIjoiaiJ9


- Creating controller for Reverify Kick-out page  screen
- Exporting GET of controller within index.ts file to be used within reverifyRoutes.ts
- Reusing acsp_is_active_middleware
- Reusing locales and view files for Kick-out page screen from Verify a clients ID service
- Adding unit tests for new screen
