### PR TITLE
Updating email sender to send emails for reverify service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.288",
+        "@companieshouse/api-sdk-node": "^2.0.293",
         "@companieshouse/ch-node-utils": "^2.1.9",
         "@companieshouse/node-session-handler": "5.2.4",
         "@companieshouse/structured-logging-node": "^2.0.1",
@@ -610,9 +610,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.291",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.291.tgz",
-      "integrity": "sha512-X7rVhSGPP1R8qSYgauqdyDBXKzuZ48yjcmJ5ZfIVOFKo7Skthcf9nRVOlz/F3ELHGRqWuaf2R40ofcI+bdouKA==",
+      "version": "2.0.293",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.293.tgz",
+      "integrity": "sha512-DpMbgiz5cTuKe/Ezo6AAobwp4YER7G03cFWqiuD0ii+rQrZofY8MGLR9/TNCyU63v38KwpNFh1j2+WhteY4BZQ==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -738,9 +738,9 @@
       }
     },
     "node_modules/@companieshouse/ch-node-utils/node_modules/eslint": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
-      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
@@ -749,7 +749,7 @@
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.35.0",
+        "@eslint/js": "9.36.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -1350,9 +1350,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
-      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5654,9 +5654,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.5.tgz",
-      "integrity": "sha512-TiU4qUT9jdCuh4aVOG7H1QozyeI2sZRqoRPdqBIaslfNt4WUSanRBueAwl2x5jt4rXBMim3lIN2x6yT8PDi24Q==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
+      "integrity": "sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7092,9 +7092,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.221",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.221.tgz",
-      "integrity": "sha512-/1hFJ39wkW01ogqSyYoA4goOXOtMRy6B+yvA1u42nnsEGtHzIzmk93aPISumVQeblj47JUHLC9coCjUxb1EvtQ==",
+      "version": "1.5.222",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.222.tgz",
+      "integrity": "sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w==",
       "dev": true,
       "license": "ISC"
     },
@@ -15954,9 +15954,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.3.tgz",
-      "integrity": "sha512-KTWbK2Wot8VXargsLoxhSoEQ9OyMdzQXQoUDeIulWu2Tf7gghuBHeg+agZqVLdTOHhQHVKAaeuctBDRkhWE7hg==",
+      "version": "29.4.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.4.tgz",
+      "integrity": "sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.288",
+    "@companieshouse/api-sdk-node": "^2.0.293",
     "@companieshouse/ch-node-utils": "^2.1.9",
     "@companieshouse/node-session-handler": "5.2.4",
     "@companieshouse/structured-logging-node": "^2.0.1",

--- a/src/controllers/checkYourAnswers.ts
+++ b/src/controllers/checkYourAnswers.ts
@@ -12,7 +12,7 @@ import { findIdentityByEmail, IdentityVerificationService, sendVerifiedClientDet
 import { saveDataInSession } from "../utils/sessionHelper";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { getAcspFullProfile, getAmlBodiesAsString } from "../services/acspProfileService";
-import { sendIdentityVerificationConfirmationEmail } from "../services/acspEmailService";
+import { sendIdentityConfirmationEmail } from "../services/acspEmailService";
 import { getLoggedInAcspNumber, getLoggedInUserEmail } from "../utils/session";
 import { ClientVerificationEmail } from "@companieshouse/api-sdk-node/dist/services/acsp/types";
 import { AcspCeasedError } from "../errors/acspCeasedError";
@@ -157,7 +157,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 clientEmailAddress: clientData.emailAddress!
             };
 
-            await sendIdentityVerificationConfirmationEmail(emailData);
+            await sendIdentityConfirmationEmail(emailData, "verification");
 
             // Sets a flag for when data is sent to verification api and email is sent
             // If user faces issue before seeing confirmation page we use this flag to check and redirect if they refresh

--- a/src/controllers/reverify-someones-identity/checkYourAnswersController.ts
+++ b/src/controllers/reverify-someones-identity/checkYourAnswersController.ts
@@ -12,7 +12,7 @@ import { findIdentityByEmail } from "../../services/identityVerificationService"
 import { saveDataInSession } from "../../utils/sessionHelper";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { getAcspFullProfile, getAmlBodiesAsString } from "../../services/acspProfileService";
-import { sendIdentityVerificationConfirmationEmail } from "../../services/acspEmailService";
+import { sendIdentityConfirmationEmail } from "../../services/acspEmailService";
 import { getLoggedInAcspNumber, getLoggedInUserEmail } from "../../utils/session";
 import { ClientVerificationEmail } from "@companieshouse/api-sdk-node/dist/services/acsp/types";
 import { AcspCeasedError } from "../../errors/acspCeasedError";
@@ -124,14 +124,14 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             const verifiedIdentityId = "123456"; // TO BE REMOVED: temporary id until endpoint developed
             saveDataInSession(req, REFERENCE, verifiedIdentityId);
 
-            const clientVerificationEmailData: ClientVerificationEmail = {
+            const clientReverificationEmailData: ClientVerificationEmail = {
                 to: getLoggedInUserEmail(req.session),
                 clientName: clientData.preferredFirstName + " " + clientData.preferredLastName,
                 referenceNumber: verifiedIdentityId,
                 clientEmailAddress: clientData.emailAddress!
             };
 
-            await sendIdentityVerificationConfirmationEmail(clientVerificationEmailData);
+            await sendIdentityConfirmationEmail(clientReverificationEmailData, "reverification");
 
             session.setExtraData(DATA_SUBMITTED_AND_EMAIL_SENT, true);
 

--- a/src/services/acspEmailService.ts
+++ b/src/services/acspEmailService.ts
@@ -4,19 +4,31 @@ import logger from "../utils/logger";
 import { HttpResponse } from "@companieshouse/api-sdk-node/dist/http";
 import { ClientVerificationEmail } from "@companieshouse/api-sdk-node/dist/services/acsp/types";
 
-export const sendIdentityVerificationConfirmationEmail = async (emailData: ClientVerificationEmail): Promise<HttpResponse> => {
-    logger.info(`Sending email to ACSP for client verification submission ID: ${emailData.referenceNumber}`);
+/**
+ * Sends an identity verification confirmation email to an ACSP for a client submission.
+ * This function handles both initial verification and reverification email notifications,
+ * routing to the appropriate email template based on the application type.
+ *
+ * @param emailData -       The client verification email data containing recipient details and reference number
+ * @param applicationType - The type of application: "verification" for verification applications
+ *                          or "reverification" for reverification applications.
+ *                          Defaults to "verification" if application_type is not specified.
+ * @returns Promise that resolves to HttpResponse on success or rejects on failure
+ */
+export const sendIdentityConfirmationEmail = async (emailData: ClientVerificationEmail, applicationType: "verification" | "reverification" = "verification"): Promise<HttpResponse> => {
+    logger.info(`Sending email to ACSP for client ${applicationType} submission ID: ${emailData.referenceNumber}`);
     const apiClient: ApiClient = createPublicApiKeyClient();
-    const sdkResponse: HttpResponse = await apiClient.acsp.sendIdentityVerificationEmail(emailData);
+
+    const sdkResponse: HttpResponse = await apiClient.acsp.sendIdentityVerificationEmail(emailData, { application_type: applicationType });
 
     if (!sdkResponse) {
-        logger.error(`Client verification email returned no response for submission ID: ${emailData.referenceNumber}`);
+        logger.error(`Client ${applicationType} email returned no response for submission ID: ${emailData.referenceNumber}`);
         return Promise.reject(sdkResponse);
     }
     if (!sdkResponse.status || sdkResponse.status >= 400) {
-        logger.error(`Http status code ${sdkResponse.status} - Client verification email Failed for submission ID: ${emailData.referenceNumber}`);
+        logger.error(`Http status code ${sdkResponse.status} - Client ${applicationType} email Failed for submission ID: ${emailData.referenceNumber}`);
         return Promise.reject(sdkResponse);
     }
-    logger.info(`Client verification email for submission ID: ${emailData.referenceNumber} has been sent`);
+    logger.info(`Client ${applicationType} email for submission ID: ${emailData.referenceNumber} has been sent`);
     return Promise.resolve(sdkResponse);
 };

--- a/test/src/controllers/checkYourAnswers.test.ts
+++ b/test/src/controllers/checkYourAnswers.test.ts
@@ -4,7 +4,7 @@ import app from "../../../src/app";
 import { BASE_URL, CHECK_YOUR_ANSWERS, CONFIRMATION } from "../../../src/types/pageURL";
 import { findIdentityByEmail, sendVerifiedClientDetails } from "../../../src/services/identityVerificationService";
 import { dummyIdentity } from "../../mocks/identity.mock";
-import { sendIdentityVerificationConfirmationEmail } from "../../../src/services/acspEmailService";
+import { sendIdentityConfirmationEmail } from "../../../src/services/acspEmailService";
 import { sessionMiddleware } from "../../../src/middleware/session_middleware";
 import { getSessionRequestWithPermission } from "../../mocks/session.mock";
 import { ACSP_DETAILS, DATA_SUBMITTED_AND_EMAIL_SENT, USER_DATA } from "../../../src/utils/constants";
@@ -20,7 +20,7 @@ jest.mock("../../../src/services/acspProfileService.ts");
 
 const mockSendVerifiedClientDetails = sendVerifiedClientDetails as jest.Mock;
 const mockFindIdentityByEmail = findIdentityByEmail as jest.Mock;
-const mockSendIdentityVerificationConfirmationEmail = sendIdentityVerificationConfirmationEmail as jest.Mock;
+const mockSendIdentityConfirmationEmail = sendIdentityConfirmationEmail as jest.Mock;
 const mockGetAcspFullProfile = getAcspFullProfile as jest.Mock;
 
 const router = supertest(app);
@@ -59,7 +59,7 @@ describe("POST " + CHECK_YOUR_ANSWERS, () => {
         createMockSessionMiddleware();
         await mockSendVerifiedClientDetails.mockResolvedValueOnce({ id: "12345" });
         await mockFindIdentityByEmail.mockResolvedValueOnce(undefined);
-        await mockSendIdentityVerificationConfirmationEmail.mockResolvedValueOnce({ status: 200 });
+        await mockSendIdentityConfirmationEmail.mockResolvedValueOnce({ status: 200 });
         await mockGetAcspFullProfile.mockResolvedValueOnce({ status: "active" });
         const res = await router.post(BASE_URL + CHECK_YOUR_ANSWERS)
             .send({ checkYourAnswerDeclaration: "confirm" });

--- a/test/src/controllers/reverify-somones-identity/checkYourAnswers.test.ts
+++ b/test/src/controllers/reverify-somones-identity/checkYourAnswers.test.ts
@@ -4,7 +4,7 @@ import app from "../../../../src/app";
 import { REVERIFY_BASE_URL, REVERIFY_CHECK_YOUR_ANSWERS, REVERIFY_CONFIRMATION } from "../../../../src/types/pageURL";
 import { findIdentityByEmail, sendVerifiedClientDetails } from "../../../../src/services/identityVerificationService";
 import { dummyIdentity } from "../../../mocks/identity.mock";
-import { sendIdentityVerificationConfirmationEmail } from "../../../../src/services/acspEmailService";
+import { sendIdentityConfirmationEmail } from "../../../../src/services/acspEmailService";
 import { sessionMiddleware } from "../../../../src/middleware/session_middleware";
 import { getSessionRequestWithPermission } from "../../../mocks/session.mock";
 import { ACSP_DETAILS, DATA_SUBMITTED_AND_EMAIL_SENT, USER_DATA } from "../../../../src/utils/constants";
@@ -20,7 +20,7 @@ jest.mock("../../../../src/services/acspProfileService.ts");
 
 const mockSendVerifiedClientDetails = sendVerifiedClientDetails as jest.Mock;
 const mockFindIdentityByEmail = findIdentityByEmail as jest.Mock;
-const mockSendIdentityVerificationConfirmationEmail = sendIdentityVerificationConfirmationEmail as jest.Mock;
+const mockSendIdentityConfirmationEmail = sendIdentityConfirmationEmail as jest.Mock;
 const mockGetAcspFullProfile = getAcspFullProfile as jest.Mock;
 
 const router = supertest(app);
@@ -59,7 +59,7 @@ describe("POST " + REVERIFY_CHECK_YOUR_ANSWERS, () => {
         createMockSessionMiddleware();
         await mockSendVerifiedClientDetails.mockResolvedValueOnce({ id: "12345" });
         await mockFindIdentityByEmail.mockResolvedValueOnce(undefined);
-        await mockSendIdentityVerificationConfirmationEmail.mockResolvedValueOnce({ status: 200 });
+        await mockSendIdentityConfirmationEmail.mockResolvedValueOnce({ status: 200 });
         await mockGetAcspFullProfile.mockResolvedValueOnce({ status: "active" });
         const res = await router.post(REVERIFY_BASE_URL + REVERIFY_CHECK_YOUR_ANSWERS)
             .send({ checkYourAnswerDeclaration: "confirm" });

--- a/test/src/services/acspEmailService.test.ts
+++ b/test/src/services/acspEmailService.test.ts
@@ -1,5 +1,5 @@
 import { createPublicApiKeyClient } from "../../../src/services/apiService";
-import { sendIdentityVerificationConfirmationEmail } from "../../../src/services/acspEmailService";
+import { sendIdentityConfirmationEmail } from "../../../src/services/acspEmailService";
 
 jest.mock("../../../src/services/apiService");
 jest.mock("@companieshouse/api-sdk-node");
@@ -24,22 +24,56 @@ describe("acspEmailService test", () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
-    it("should return http status code 200 when email sends successfully", async () => {
-        mockSendIdentityVerificationEmail.mockResolvedValueOnce({ status: 200 });
-        await expect(sendIdentityVerificationConfirmationEmail(MOCK_EMAIL_DATA)).resolves.toEqual({ status: 200 });
+
+    describe("Verification emails", () => {
+        it("should return http status code 200 when verification email sends successfully", async () => {
+            mockSendIdentityVerificationEmail.mockResolvedValueOnce({ status: 200 });
+            await expect(sendIdentityConfirmationEmail(MOCK_EMAIL_DATA, "verification")).resolves.toEqual({ status: 200 });
+            expect(mockSendIdentityVerificationEmail).toHaveBeenCalledWith(MOCK_EMAIL_DATA, { application_type: "verification" });
+        });
+
+        it("should use verification as default when no application type is provided", async () => {
+            mockSendIdentityVerificationEmail.mockResolvedValueOnce({ status: 200 });
+            await expect(sendIdentityConfirmationEmail(MOCK_EMAIL_DATA)).resolves.toEqual({ status: 200 });
+            expect(mockSendIdentityVerificationEmail).toHaveBeenCalledWith(MOCK_EMAIL_DATA, { application_type: "verification" });
+        });
+
+        it("should reject the promise when verification email API returns undefined", async () => {
+            mockSendIdentityVerificationEmail.mockResolvedValueOnce(undefined);
+            await expect(sendIdentityConfirmationEmail(MOCK_EMAIL_DATA, "verification")).rejects.toEqual(undefined);
+        });
+
+        it("should reject the promise when verification email API returns a status code over 400", async () => {
+            mockSendIdentityVerificationEmail.mockResolvedValueOnce({ status: 500 });
+            await expect(sendIdentityConfirmationEmail(MOCK_EMAIL_DATA, "verification")).rejects.toEqual({ status: 500 });
+        });
+
+        it("should reject the promise when verification email API returns no status code", async () => {
+            mockSendIdentityVerificationEmail.mockResolvedValueOnce({ body: "error body" });
+            await expect(sendIdentityConfirmationEmail(MOCK_EMAIL_DATA, "verification")).rejects.toEqual({ body: "error body" });
+        });
     });
 
-    it("Should reject the promise when acsp-api returns undefined", async () => {
-        mockSendIdentityVerificationEmail.mockResolvedValueOnce(undefined);
-        await expect(sendIdentityVerificationConfirmationEmail(MOCK_EMAIL_DATA)).rejects.toEqual(undefined);
-    });
+    describe("Reverification emails", () => {
+        it("should return http status code 200 when reverification email sends successfully", async () => {
+            mockSendIdentityVerificationEmail.mockResolvedValueOnce({ status: 200 });
+            await expect(sendIdentityConfirmationEmail(MOCK_EMAIL_DATA, "reverification")).resolves.toEqual({ status: 200 });
+            expect(mockSendIdentityVerificationEmail).toHaveBeenCalledWith(MOCK_EMAIL_DATA, { application_type: "reverification" });
+        });
 
-    it("Should reject the promise when acsp-api returns a status code over 400", async () => {
-        mockSendIdentityVerificationEmail.mockResolvedValueOnce({ status: 500 });
-        await expect(sendIdentityVerificationConfirmationEmail(MOCK_EMAIL_DATA)).rejects.toEqual({ status: 500 });
-    });
-    it("Should reject the promise when acsp-api returns no status code", async () => {
-        mockSendIdentityVerificationEmail.mockResolvedValueOnce({ body: "error body" });
-        await expect(sendIdentityVerificationConfirmationEmail(MOCK_EMAIL_DATA)).rejects.toEqual({ body: "error body" });
+        it("should reject the promise when reverification email API returns undefined", async () => {
+            mockSendIdentityVerificationEmail.mockResolvedValueOnce(undefined);
+            await expect(sendIdentityConfirmationEmail(MOCK_EMAIL_DATA, "reverification")).rejects.toEqual(undefined);
+        });
+
+        it("should reject the promise when reverification email API returns a status code over 400", async () => {
+            mockSendIdentityVerificationEmail.mockResolvedValueOnce({ status: 500 });
+            await expect(sendIdentityConfirmationEmail(MOCK_EMAIL_DATA, "reverification")).rejects.toEqual({ status: 500 });
+        });
+
+        it("should reject the promise when reverification email API returns no status code", async () => {
+            mockSendIdentityVerificationEmail.mockResolvedValueOnce({ body: "error body" });
+            await expect(sendIdentityConfirmationEmail(MOCK_EMAIL_DATA, "reverification")).rejects.toEqual({ body: "error body" });
+        });
     });
 });


### PR DESCRIPTION
Changes required for ticket:
[IDVA5-2643](https://companieshouse.atlassian.net/browse/IDVA5-2643)

- Updating `acspEmailService` method to add a check for the optional query parameter.
- This has been updated to account for sending reverification emails when the request comes from the reverification service
- Updated method name to reflect the change
- Updated api-sdk-node tag to pull in the relevant changes made to `sendIdentityVerificationEmail` method
- Calling the  updated `sendIdentityConfirmationEmail` method within each service's check your answer controller and including the query parameter for the application type ("verification" for Verify service emails and "reverification" for Reverify service)
- Updating unit tests

[IDVA5-2643]: https://companieshouse.atlassian.net/browse/IDVA5-2643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ